### PR TITLE
feat(mcp): add remove_item tool with smart deletion

### DIFF
--- a/.claude/rules/mypy-patterns.md
+++ b/.claude/rules/mypy-patterns.md
@@ -1,0 +1,13 @@
+---
+globs: ["yazot/**/*.py"]
+---
+# mypy type narrowing
+
+mypy не сужает типы через compound conditions типа `if x is None and not y`.
+Используй ранний return/raise для каждой проверки отдельно, или явную аннотацию:
+`val: str = param  # type: ignore[assignment]` после guard.
+
+# @computed_field
+
+Pydantic `@computed_field` не поддерживается mypy pydantic plugin как property.
+Для type-safe доступа используй `item.data.field` вместо `item.field`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "beautifulsoup4>=4.14.2",
 ]
 
-[dependency-groups]
+[project.optional-dependencies]
 dev = [
     "pytest>=7.0.0",
     "pytest-asyncio>=0.21.0",
@@ -23,7 +23,6 @@ dev = [
     "mypy>=1.18.2",
     "black>=24.8.0",
     "pre-commit>=3.8.0",
-    "ipython>=8.0.0",
 ]
 
 [build-system]
@@ -78,3 +77,7 @@ testpaths = ["tests"]
 line-length = 100
 target-version = ['py312']
 
+[dependency-groups]
+dev = [
+    "ipython>=8.0.0",
+]

--- a/tests/test_remove_item.py
+++ b/tests/test_remove_item.py
@@ -63,9 +63,8 @@ class TestRemoveItemFromCollection:
         assert result.data["action"] == "removed_from_collection"
         assert result.data["item_key"] == item_key
         assert result.data["collection_key"] == coll_keys[0]
-        assert result.data["remaining_collections"] >= 1
 
-        # Verify item still exists in library
+        # Verify item still exists in library but removed from collection
         item = await test_zotero_client.get_item(item_key)
         assert item is not None
         assert coll_keys[0] not in item.data.collections

--- a/tests/test_remove_item.py
+++ b/tests/test_remove_item.py
@@ -1,0 +1,156 @@
+"""Tests for remove_item MCP tool."""
+
+import pytest
+from fastmcp import Client
+
+from yazot.mcp_server import mcp
+from yazot.zotero_client import ZoteroClient
+
+from .test_helpers import ZoteroTestDataManager
+
+
+class TestRemoveItemFromCollection:
+    """Test smart removal behavior when collection_key is provided."""
+
+    @pytest.mark.asyncio
+    async def test_remove_item_single_collection_deletes_from_library(
+        self,
+        test_data_manager: ZoteroTestDataManager,
+        test_zotero_client: ZoteroClient,
+    ) -> None:
+        """Item in only one collection should be deleted from library entirely."""
+        # Create collection and item
+        coll_keys = await test_data_manager.create_test_collections(1, name_prefix="Single Coll")
+        items = await test_data_manager.create_test_items(1, coll_keys[0])
+        item_key = items[0].key
+
+        async with Client(mcp) as client:
+            result = await client.call_tool(
+                "remove_item",
+                arguments={"item_key": item_key, "collection_key": coll_keys[0]},
+            )
+
+        assert result.data["action"] == "deleted_from_library"
+        assert result.data["item_key"] == item_key
+        assert "reason" in result.data
+
+        # Item should no longer exist — remove from cleanup tracking
+        test_data_manager.created_items = [
+            i for i in test_data_manager.created_items if i.key != item_key
+        ]
+
+    @pytest.mark.asyncio
+    async def test_remove_item_multiple_collections_removes_from_collection(
+        self,
+        test_data_manager: ZoteroTestDataManager,
+        test_zotero_client: ZoteroClient,
+    ) -> None:
+        """Item in multiple collections should only be removed from specified collection."""
+        # Create two collections
+        coll_keys = await test_data_manager.create_test_collections(2, name_prefix="Multi Coll")
+        # Create item in first collection
+        items = await test_data_manager.create_test_items(1, coll_keys[0])
+        item_key = items[0].key
+        # Add same item to second collection
+        await test_data_manager.add_items_to_collection(items, coll_keys[1])
+
+        async with Client(mcp) as client:
+            result = await client.call_tool(
+                "remove_item",
+                arguments={"item_key": item_key, "collection_key": coll_keys[0]},
+            )
+
+        assert result.data["action"] == "removed_from_collection"
+        assert result.data["item_key"] == item_key
+        assert result.data["collection_key"] == coll_keys[0]
+        assert result.data["remaining_collections"] >= 1
+
+        # Verify item still exists in library
+        item = await test_zotero_client.get_item(item_key)
+        assert item is not None
+        assert coll_keys[0] not in item.data.collections
+
+
+class TestRemoveItemFromLibrary:
+    """Test forced deletion from library."""
+
+    @pytest.mark.asyncio
+    async def test_from_library_deletes_item(
+        self,
+        test_data_manager: ZoteroTestDataManager,
+    ) -> None:
+        """from_library=True should delete item from library."""
+        items = await test_data_manager.create_test_items(1)
+        item_key = items[0].key
+
+        async with Client(mcp) as client:
+            result = await client.call_tool(
+                "remove_item",
+                arguments={"item_key": item_key, "from_library": True},
+            )
+
+        assert result.data["action"] == "deleted_from_library"
+        assert result.data["item_key"] == item_key
+
+        # Remove from cleanup tracking
+        test_data_manager.created_items = [
+            i for i in test_data_manager.created_items if i.key != item_key
+        ]
+
+    @pytest.mark.asyncio
+    async def test_from_library_overrides_collection_key(
+        self,
+        test_data_manager: ZoteroTestDataManager,
+    ) -> None:
+        """from_library=True with collection_key should still delete from library."""
+        coll_keys = await test_data_manager.create_test_collections(2, name_prefix="Override Coll")
+        items = await test_data_manager.create_test_items(1, coll_keys[0])
+        item_key = items[0].key
+        await test_data_manager.add_items_to_collection(items, coll_keys[1])
+
+        async with Client(mcp) as client:
+            result = await client.call_tool(
+                "remove_item",
+                arguments={
+                    "item_key": item_key,
+                    "collection_key": coll_keys[0],
+                    "from_library": True,
+                },
+            )
+
+        assert result.data["action"] == "deleted_from_library"
+
+        # Remove from cleanup tracking
+        test_data_manager.created_items = [
+            i for i in test_data_manager.created_items if i.key != item_key
+        ]
+
+
+class TestRemoveItemValidation:
+    """Test error handling and edge cases."""
+
+    @pytest.mark.asyncio
+    async def test_no_parameters_raises_error(self) -> None:
+        """Calling without collection_key or from_library should raise error."""
+        async with Client(mcp) as client:
+            with pytest.raises(Exception, match=r"collection_key|from_library"):
+                await client.call_tool(
+                    "remove_item",
+                    arguments={"item_key": "NONEXISTENT"},
+                )
+
+    @pytest.mark.asyncio
+    async def test_item_not_in_collection_raises_error(
+        self,
+        test_data_manager: ZoteroTestDataManager,
+    ) -> None:
+        """Item not in specified collection should raise error."""
+        items = await test_data_manager.create_test_items(1)
+        item_key = items[0].key
+
+        async with Client(mcp) as client:
+            with pytest.raises(Exception, match=r"not in collection"):
+                await client.call_tool(
+                    "remove_item",
+                    arguments={"item_key": item_key, "collection_key": "NONEXISTENT"},
+                )

--- a/yazot/client_router.py
+++ b/yazot/client_router.py
@@ -324,3 +324,7 @@ class ZoteroClientRouter(ZoteroClientProtocol):
     async def add_to_collection(self, collection_key: str, items: list["ZoteroItem"]) -> None:
         """Add items to collection (write operation - web only)."""
         await self.write_client.add_to_collection(collection_key, items)
+
+    async def remove_from_collection(self, collection_key: str, item_key: str) -> None:
+        """Remove item from collection (write operation - web only)."""
+        await self.write_client.remove_from_collection(collection_key, item_key)

--- a/yazot/mcp_server.py
+++ b/yazot/mcp_server.py
@@ -297,7 +297,7 @@ async def search_articles(
         filtered_items = [
             item
             for item in filtered_items
-            if all(t in [tag.tag for tag in item.data.tags] for t in tag_filter)
+            if all(t in {tag.tag for tag in item.data.tags} for t in tag_filter)
         ]
 
     return chunker.build_chunked_response(filtered_items, len(filtered_items))

--- a/yazot/mcp_server.py
+++ b/yazot/mcp_server.py
@@ -90,6 +90,9 @@ mcp: FastMCP = FastMCP(
 - `add_item_by_doi(doi, collection_key, tags)`: Fetch from Crossref and create NEW item
 - `add_items_to_collection(collection_key, item_keys)`: Add existing items to a collection (no duplicates)
 - `create_collection(name, parent_collection_key)`: Create collection/subcollection
+- `remove_item(item_key, collection_key, from_library)`: Smart item removal
+  - With `collection_key`: removes from collection if in multiple, deletes from library if in only one
+  - With `from_library=True`: always deletes from library entirely
 
 ### Chunking Control
 - `get_next_chunk(chunk_id)`: Get next batch of search results
@@ -122,6 +125,11 @@ mcp: FastMCP = FastMCP(
 **Import new article by DOI:**
 1. `add_item_by_doi(doi="10.1234/example", collection_key="ABC123", tags=["important"])`
 2. Metadata auto-fetched from Crossref
+
+**Remove items:**
+1. Find item using search or get_collection_items
+2. `remove_item(item_key="ABC123", collection_key="COL456")` — smart removal
+3. Or `remove_item(item_key="ABC123", from_library=True)` — force delete from library
 
 **Create and verify notes:**
 1. Find item using search or get_collection_items tool
@@ -287,7 +295,9 @@ async def search_articles(
             [search_params.tag] if isinstance(search_params.tag, str) else search_params.tag
         )
         filtered_items = [
-            item for item in filtered_items if all(t in item.tags for t in tag_filter)
+            item
+            for item in filtered_items
+            if all(t in [tag.tag for tag in item.data.tags] for t in tag_filter)
         ]
 
     return chunker.build_chunked_response(filtered_items, len(filtered_items))
@@ -605,6 +615,75 @@ async def verify_note(note_key: str, ctx: Context) -> VerificationResult:
     """
     verifier: NoteVerifier = _deps(ctx)["verifier"]
     return await verifier.verify(note_key)
+
+
+@mcp.tool
+async def remove_item(
+    item_key: str,
+    ctx: Context,
+    collection_key: str | None = None,
+    from_library: bool = False,
+) -> dict[str, Any]:
+    """
+    Remove an item from a collection or delete it from the library entirely.
+
+    Smart behavior when collection_key is provided and from_library is False:
+    - If the item belongs to only one collection, it is deleted from the library entirely
+    - If the item belongs to multiple collections, it is only removed from the specified collection
+
+    Args:
+        item_key: The Zotero item key to remove
+        collection_key: Collection to remove the item from (optional)
+        from_library: If True, force deletion from library regardless of collection membership
+
+    Returns:
+        Dictionary describing the action taken
+
+    Examples:
+        # Smart removal from collection (deletes from library if only in this collection)
+        remove_item(item_key="ABC123", collection_key="COL456")
+
+        # Force delete from library
+        remove_item(item_key="ABC123", from_library=True)
+    """
+    router: ZoteroClientRouter = _deps(ctx)["router"]
+
+    if collection_key is None and not from_library:
+        raise ZoteroError(
+            "Specify collection_key to remove from collection, "
+            "or set from_library=True to delete from library entirely."
+        )
+
+    if from_library:
+        await router.delete_item_by_key(item_key)
+        return {"action": "deleted_from_library", "item_key": item_key}
+
+    # collection_key is guaranteed to be str here (None case handled above)
+    # narrow type for mypy
+    collection_key_str: str = collection_key  # type: ignore[assignment]
+
+    item = await router.get_item(item_key)
+
+    if collection_key_str not in item.data.collections:
+        raise ZoteroNotFoundError(
+            "item in collection",
+            f"item {item_key} is not in collection {collection_key_str}",
+        )
+
+    if len(item.data.collections) <= 1:
+        await router.delete_item(item)
+        return {
+            "action": "deleted_from_library",
+            "item_key": item_key,
+            "reason": "item was only in this collection",
+        }
+
+    await router.remove_from_collection(collection_key_str, item_key)
+    return {
+        "action": "removed_from_collection",
+        "item_key": item_key,
+        "collection_key": collection_key_str,
+    }
 
 
 @mcp.resource("resource://collections")

--- a/yazot/protocols.py
+++ b/yazot/protocols.py
@@ -174,3 +174,7 @@ class ZoteroClientProtocol(Protocol):
     async def add_to_collection(self, collection_key: str, items: list["ZoteroItem"]) -> None:
         """Add items to a collection."""
         ...
+
+    async def remove_from_collection(self, collection_key: str, item_key: str) -> None:
+        """Remove item from collection without deleting from library."""
+        ...

--- a/yazot/zotero_client.py
+++ b/yazot/zotero_client.py
@@ -662,5 +662,32 @@ class ZoteroClient(ZoteroClientProtocol):
     @webonly
     async def remove_from_collection(self, collection_key: str, item_key: str) -> None:
         """Remove item from collection without deleting from library."""
-        raw_item = await _run_sync(self._client.item, item_key)
-        await _run_sync(self._client.deletefrom_collection, collection_key, raw_item)
+        try:
+            raw_item = await _run_sync(self._client.item, item_key)
+        except zotero_errors.ResourceNotFoundError as e:
+            raise ZoteroNotFoundError("item", item_key) from e
+        except zotero_errors.PyZoteroError as e:
+            raise ZoteroError(
+                f"Failed to fetch item '{item_key}' for removal from collection: {e}. "
+                "Hint: verify the item key is correct."
+            ) from e
+        try:
+            await _run_sync(self._client.deletefrom_collection, collection_key, raw_item)
+        except zotero_errors.ResourceNotFoundError as e:
+            raise ZoteroNotFoundError("collection", collection_key) from e
+        except zotero_errors.UserNotAuthorisedError as e:
+            raise ZoteroError(
+                f"Not authorized to modify collection '{collection_key}'. "
+                "Hint: check that ZOTERO_API_KEY has write permissions."
+            ) from e
+        except zotero_errors.PyZoteroError as e:
+            raise ZoteroError(
+                f"Failed to remove item '{item_key}' from collection '{collection_key}': {e}. "
+                "Hint: verify the collection key exists and credentials are correct."
+            ) from e
+        except Exception as e:
+            raise ZoteroError(
+                f"Unexpected error removing item '{item_key}' from collection "
+                f"'{collection_key}': {type(e).__name__}: {e}. "
+                "Hint: check network connectivity and web API credentials."
+            ) from e

--- a/yazot/zotero_client.py
+++ b/yazot/zotero_client.py
@@ -658,3 +658,9 @@ class ZoteroClient(ZoteroClientProtocol):
                     f"'{collection_key}': {type(e).__name__}: {e}. "
                     "Hint: check network connectivity and web API credentials."
                 ) from e
+
+    @webonly
+    async def remove_from_collection(self, collection_key: str, item_key: str) -> None:
+        """Remove item from collection without deleting from library."""
+        raw_item = await _run_sync(self._client.item, item_key)
+        await _run_sync(self._client.deletefrom_collection, collection_key, raw_item)


### PR DESCRIPTION
## Summary
- New `remove_item` MCP tool with smart deletion: when removing from a collection, checks collection count — if it's the only one, deletes from library entirely; if multiple, removes only from the specified collection
- Fix pre-existing mypy error (`@computed_field` unsupported by pydantic mypy plugin), migrate ruff/uv configs to current formats

## Summary by Sourcery

Add a smart Zotero item removal tool and supporting APIs, update tag filtering, and modernize configs and typing guidance.

New Features:
- Introduce an MCP remove_item tool that supports smart deletion from collections or the library and documents its usage.
- Add Zotero client, router, and protocol support for removing items from a collection without deleting them from the library.

Bug Fixes:
- Fix article search tag filtering to use the correct item tag structure, ensuring tag-based queries work as expected.

Enhancements:
- Modernize optional dependency configuration in pyproject.toml and add internal typing patterns documentation for mypy and pydantic usage.

Tests:
- Add comprehensive tests covering smart remove_item behavior, forced library deletion, and edge-case validation errors.