### PR TITLE
feat: external fulltext retrieval (Unpaywall → CORE → Libgen)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "pydantic>=2.0.0",
     "pydantic-settings>=2.0.0",
     "python-dotenv>=1.0.0",
+    "httpx>=0.27.0",
     "pypdf>=4.0.0",
     "beautifulsoup4>=4.14.2",
 ]

--- a/tests/test_e2e_external_fulltext.py
+++ b/tests/test_e2e_external_fulltext.py
@@ -1,0 +1,271 @@
+"""E2E tests for fetch_external_fulltext MCP tool.
+
+Tests the full MCP tool flow via Client(mcp), mocking external HTTP calls
+(Unpaywall/CORE/Libgen) while using real MCP lifespan and TextChunker.
+"""
+
+import io
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastmcp import Client
+from fastmcp.exceptions import ToolError
+from pypdf import PdfWriter
+
+from yazot.mcp_server import mcp
+
+
+def _make_pdf_bytes(pages: int = 1, text: str = "Sample text") -> bytes:
+    """Create valid PDF bytes. Text extraction is mocked separately."""
+    writer = PdfWriter()
+    for _ in range(pages):
+        writer.add_blank_page(width=200, height=200)
+    buf = io.BytesIO()
+    writer.write(buf)
+    return buf.getvalue()
+
+
+class TestFetchExternalFulltext:
+    """E2E tests for fetch_external_fulltext via Client(mcp)."""
+
+    @pytest.fixture(autouse=True)
+    def _setup_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Configure env for external fulltext resolver."""
+        monkeypatch.setenv("UNPAYWALL_EMAIL", "test@example.com")
+        monkeypatch.setenv("CORE_API_KEY", "test-core-key")
+
+    @pytest.mark.asyncio
+    async def test_fetch_by_doi_returns_text(self) -> None:
+        """Basic flow: DOI → Unpaywall → download PDF → extract text."""
+        pdf_bytes = _make_pdf_bytes()
+
+        with (
+            patch(
+                "yazot.fulltext_resolver.UnpaywallClient.find_pdf_url",
+                new_callable=AsyncMock,
+                return_value="https://example.com/paper.pdf",
+            ),
+            patch(
+                "yazot.fulltext_resolver.FulltextResolver.download",
+                new_callable=AsyncMock,
+                return_value=pdf_bytes,
+            ),
+            patch(
+                "yazot.fulltext_resolver.FulltextResolver.extract_text",
+                return_value="This is the extracted fulltext content from the PDF.",
+            ),
+        ):
+            async with Client(mcp) as client:
+                result = await client.call_tool(
+                    "fetch_external_fulltext",
+                    arguments={"doi": "10.1234/test"},
+                )
+                response = result.data
+
+        assert response.content == "This is the extracted fulltext content from the PDF."
+        assert response.source == "unpaywall"
+        assert response.error is None
+        assert response.item_key is None
+
+    @pytest.mark.asyncio
+    async def test_fetch_by_title_returns_text(self) -> None:
+        """Search by title when no DOI provided — falls through to CORE."""
+        pdf_bytes = _make_pdf_bytes()
+
+        with (
+            patch(
+                "yazot.fulltext_resolver.CoreClient.find_pdf_url",
+                new_callable=AsyncMock,
+                return_value="https://core.ac.uk/download/pdf/123.pdf",
+            ),
+            patch(
+                "yazot.fulltext_resolver.FulltextResolver.download",
+                new_callable=AsyncMock,
+                return_value=pdf_bytes,
+            ),
+            patch(
+                "yazot.fulltext_resolver.FulltextResolver.extract_text",
+                return_value="Extracted text from CORE source.",
+            ),
+        ):
+            async with Client(mcp) as client:
+                result = await client.call_tool(
+                    "fetch_external_fulltext",
+                    arguments={"title": "Machine Learning in Medicine"},
+                )
+                response = result.data
+
+        assert response.content == "Extracted text from CORE source."
+        assert response.source == "core"
+
+    @pytest.mark.asyncio
+    async def test_cascade_unpaywall_fails_core_succeeds(self) -> None:
+        """Unpaywall returns None → fallback to CORE."""
+        pdf_bytes = _make_pdf_bytes()
+
+        with (
+            patch(
+                "yazot.fulltext_resolver.UnpaywallClient.find_pdf_url",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "yazot.fulltext_resolver.CoreClient.find_pdf_url",
+                new_callable=AsyncMock,
+                return_value="https://core.ac.uk/pdf/456.pdf",
+            ),
+            patch(
+                "yazot.fulltext_resolver.FulltextResolver.download",
+                new_callable=AsyncMock,
+                return_value=pdf_bytes,
+            ),
+            patch(
+                "yazot.fulltext_resolver.FulltextResolver.extract_text",
+                return_value="Content from CORE after Unpaywall miss.",
+            ),
+        ):
+            async with Client(mcp) as client:
+                result = await client.call_tool(
+                    "fetch_external_fulltext",
+                    arguments={"doi": "10.1234/closed-access", "title": "Closed Paper"},
+                )
+                response = result.data
+
+        assert response.source == "core"
+        assert "Content from CORE" in response.content
+
+    @pytest.mark.asyncio
+    async def test_all_sources_fail_raises_error(self) -> None:
+        """All sources return None → FulltextNotFoundError shown to client."""
+        with (
+            patch(
+                "yazot.fulltext_resolver.UnpaywallClient.find_pdf_url",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "yazot.fulltext_resolver.CoreClient.find_pdf_url",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            pytest.raises(ToolError, match="No fulltext found"),
+        ):
+            async with Client(mcp) as client:
+                await client.call_tool(
+                    "fetch_external_fulltext",
+                    arguments={"doi": "10.9999/nonexistent"},
+                )
+
+    @pytest.mark.asyncio
+    async def test_no_doi_no_title_raises_error(self) -> None:
+        """Neither doi nor title provided → ZoteroError."""
+        with pytest.raises(ToolError, match="At least one of doi or title"):
+            async with Client(mcp) as client:
+                await client.call_tool(
+                    "fetch_external_fulltext",
+                    arguments={},
+                )
+
+    @pytest.mark.asyncio
+    async def test_empty_text_extraction_returns_error(self) -> None:
+        """PDF downloads OK but text extraction yields empty string."""
+        pdf_bytes = _make_pdf_bytes()
+
+        with (
+            patch(
+                "yazot.fulltext_resolver.UnpaywallClient.find_pdf_url",
+                new_callable=AsyncMock,
+                return_value="https://example.com/scanned.pdf",
+            ),
+            patch(
+                "yazot.fulltext_resolver.FulltextResolver.download",
+                new_callable=AsyncMock,
+                return_value=pdf_bytes,
+            ),
+            patch(
+                "yazot.fulltext_resolver.FulltextResolver.extract_text",
+                return_value="   ",
+            ),
+        ):
+            async with Client(mcp) as client:
+                result = await client.call_tool(
+                    "fetch_external_fulltext",
+                    arguments={"doi": "10.1234/scanned"},
+                )
+                response = result.data
+
+        assert response.content == ""
+        assert response.error is not None
+        assert "no text" in response.error.lower()
+
+    @pytest.mark.asyncio
+    async def test_chunking_with_large_text(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Large text is chunked and retrievable via get_next_fulltext_chunk."""
+        monkeypatch.setenv("MAX_CHUNK_SIZE", "100")
+        # Generate text larger than 100 tokens (400+ chars)
+        large_text = "This is paragraph one. " * 50 + "\n\n" + "Second paragraph here. " * 50
+        pdf_bytes = _make_pdf_bytes()
+
+        with (
+            patch(
+                "yazot.fulltext_resolver.UnpaywallClient.find_pdf_url",
+                new_callable=AsyncMock,
+                return_value="https://example.com/large.pdf",
+            ),
+            patch(
+                "yazot.fulltext_resolver.FulltextResolver.download",
+                new_callable=AsyncMock,
+                return_value=pdf_bytes,
+            ),
+            patch(
+                "yazot.fulltext_resolver.FulltextResolver.extract_text",
+                return_value=large_text,
+            ),
+        ):
+            async with Client(mcp) as client:
+                result = await client.call_tool(
+                    "fetch_external_fulltext",
+                    arguments={"doi": "10.1234/large"},
+                )
+                response = result.data
+
+                assert response.has_more is True
+                assert response.chunk_id is not None
+                assert response.source == "unpaywall"
+                assert "get_next_fulltext_chunk" in (response.message or "")
+
+                # Retrieve all remaining chunks
+                all_content = response.content
+                while response.has_more:
+                    chunk_result = await client.call_tool(
+                        "get_next_fulltext_chunk",
+                        arguments={"chunk_id": response.chunk_id},
+                    )
+                    response = chunk_result.data
+                    all_content += response.content
+
+        # Reassembled content should match original
+        assert len(all_content) > 0
+        assert "paragraph one" in all_content
+        assert "Second paragraph" in all_content
+
+
+class TestFetchExternalFulltextNotConfigured:
+    """Tests when no external sources are configured."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Ensure no external fulltext config is set."""
+        monkeypatch.delenv("UNPAYWALL_EMAIL", raising=False)
+        monkeypatch.delenv("CORE_API_KEY", raising=False)
+        monkeypatch.delenv("FULLTEXT_LIBGEN_ENABLED", raising=False)
+
+    @pytest.mark.asyncio
+    async def test_not_configured_raises_error(self) -> None:
+        """Tool raises ConfigurationError when no sources configured."""
+        with pytest.raises(ToolError, match="not configured"):
+            async with Client(mcp) as client:
+                await client.call_tool(
+                    "fetch_external_fulltext",
+                    arguments={"doi": "10.1234/test"},
+                )

--- a/tests/test_fulltext_resolver.py
+++ b/tests/test_fulltext_resolver.py
@@ -420,6 +420,21 @@ class TestFulltextResolver:
         ):
             await resolver.download("https://example.com/not-a-pdf")
 
+    async def test_download_empty_pdf_body(self, settings_all: Settings) -> None:
+        resolver = FulltextResolver(settings_all)
+        mock_response = make_httpx_response(
+            content=b"",
+            headers={"content-type": "application/pdf"},
+        )
+
+        with (
+            patch.object(
+                resolver._http, "get", new_callable=AsyncMock, return_value=mock_response
+            ),
+            pytest.raises(FulltextDownloadError, match="Empty response body"),
+        ):
+            await resolver.download("https://example.com/empty.pdf")
+
     async def test_download_http_error(self, settings_all: Settings) -> None:
         resolver = FulltextResolver(settings_all)
         mock_response = make_httpx_response(status_code=403)
@@ -446,6 +461,19 @@ class TestFulltextResolver:
             text = resolver.extract_text(pdf_bytes)
 
         assert text == "Page 1 text"
+
+    def test_extract_text_pdf_parse_failure(self, settings_all: Settings) -> None:
+        resolver = FulltextResolver(settings_all)
+        pdf_bytes = make_pdf_bytes()
+
+        with (
+            patch(
+                "yazot.fulltext_resolver.PdfReader",
+                side_effect=ValueError("corrupt"),
+            ),
+            pytest.raises(FulltextDownloadError, match="Failed to parse PDF"),
+        ):
+            resolver.extract_text(pdf_bytes)
 
     def test_extract_text_multiple_pages(self, settings_all: Settings) -> None:
         resolver = FulltextResolver(settings_all)

--- a/tests/test_fulltext_resolver.py
+++ b/tests/test_fulltext_resolver.py
@@ -1,0 +1,482 @@
+"""Tests for external fulltext resolver — Unpaywall, CORE, Libgen clients + cascade."""
+
+import io
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from pypdf import PdfWriter
+
+from yazot.config import Settings
+from yazot.exceptions import (
+    FulltextDownloadError,
+    FulltextNotFoundError,
+    FulltextSourceError,
+)
+from yazot.fulltext_resolver import (
+    CoreClient,
+    FulltextResolver,
+    LibgenClient,
+    UnpaywallClient,
+)
+
+# --- Helpers ---
+
+
+def make_pdf_bytes(text: str = "Sample PDF text content") -> bytes:
+    """Create minimal valid PDF bytes for testing."""
+    writer = PdfWriter()
+    writer.add_blank_page(width=200, height=200)
+    buf = io.BytesIO()
+    writer.write(buf)
+    return buf.getvalue()
+
+
+def make_httpx_response(
+    status_code: int = 200,
+    json_data: dict | None = None,
+    content: bytes = b"",
+    headers: dict | None = None,
+) -> httpx.Response:
+    """Create a mock httpx.Response."""
+    if json_data is not None:
+        content = json.dumps(json_data).encode()
+        headers = {**(headers or {}), "content-type": "application/json"}
+    resp = httpx.Response(
+        status_code=status_code,
+        content=content,
+        headers=headers or {},
+        request=httpx.Request("GET", "https://example.com"),
+    )
+    return resp
+
+
+# --- UnpaywallClient tests ---
+
+
+class TestUnpaywallClient:
+    @pytest.fixture
+    def client(self) -> UnpaywallClient:
+        return UnpaywallClient(email="test@example.com")
+
+    async def test_find_pdf_url_success(self, client: UnpaywallClient) -> None:
+        response_data = {
+            "doi": "10.1234/test",
+            "is_oa": True,
+            "best_oa_location": {
+                "url_for_pdf": "https://example.com/paper.pdf",
+                "url": "https://example.com/paper",
+                "is_best": True,
+            },
+            "oa_locations": [],
+        }
+        mock_response = make_httpx_response(json_data=response_data)
+
+        with patch.object(client.client, "get", new_callable=AsyncMock, return_value=mock_response):
+            url = await client.find_pdf_url("10.1234/test")
+
+        assert url == "https://example.com/paper.pdf"
+
+    async def test_find_pdf_url_fallback_to_oa_locations(
+        self, client: UnpaywallClient
+    ) -> None:
+        response_data = {
+            "doi": "10.1234/test",
+            "is_oa": True,
+            "best_oa_location": {"url_for_pdf": None, "url": "https://example.com"},
+            "oa_locations": [
+                {"url_for_pdf": None},
+                {"url_for_pdf": "https://archive.org/paper.pdf"},
+            ],
+        }
+        mock_response = make_httpx_response(json_data=response_data)
+
+        with patch.object(client.client, "get", new_callable=AsyncMock, return_value=mock_response):
+            url = await client.find_pdf_url("10.1234/test")
+
+        assert url == "https://archive.org/paper.pdf"
+
+    async def test_find_pdf_url_not_found(self, client: UnpaywallClient) -> None:
+        mock_response = make_httpx_response(status_code=404)
+
+        with patch.object(client.client, "get", new_callable=AsyncMock, return_value=mock_response):
+            url = await client.find_pdf_url("10.1234/nonexistent")
+
+        assert url is None
+
+    async def test_find_pdf_url_no_oa(self, client: UnpaywallClient) -> None:
+        response_data = {
+            "doi": "10.1234/closed",
+            "is_oa": False,
+            "best_oa_location": None,
+            "oa_locations": [],
+        }
+        mock_response = make_httpx_response(json_data=response_data)
+
+        with patch.object(client.client, "get", new_callable=AsyncMock, return_value=mock_response):
+            url = await client.find_pdf_url("10.1234/closed")
+
+        assert url is None
+
+    async def test_find_pdf_url_server_error(self, client: UnpaywallClient) -> None:
+        mock_response = make_httpx_response(status_code=500)
+
+        with (
+            patch.object(client.client, "get", new_callable=AsyncMock, return_value=mock_response),
+            pytest.raises(FulltextSourceError, match="Unpaywall"),
+        ):
+            await client.find_pdf_url("10.1234/test")
+
+
+# --- CoreClient tests ---
+
+
+class TestCoreClient:
+    @pytest.fixture
+    def client(self) -> CoreClient:
+        return CoreClient(api_key="test-key")
+
+    async def test_find_pdf_url_by_doi(self, client: CoreClient) -> None:
+        response_data = {
+            "totalHits": 1,
+            "results": [
+                {
+                    "id": 12345,
+                    "doi": "10.1234/test",
+                    "downloadUrl": "https://core.ac.uk/download/pdf/12345.pdf",
+                    "title": "Test Article",
+                }
+            ],
+        }
+        mock_response = make_httpx_response(json_data=response_data)
+
+        with patch.object(client.client, "get", new_callable=AsyncMock, return_value=mock_response):
+            url = await client.find_pdf_url("10.1234/test", None)
+
+        assert url == "https://core.ac.uk/download/pdf/12345.pdf"
+
+    async def test_find_pdf_url_by_title(self, client: CoreClient) -> None:
+        response_data = {
+            "totalHits": 1,
+            "results": [
+                {
+                    "id": 67890,
+                    "downloadUrl": "https://core.ac.uk/download/pdf/67890.pdf",
+                    "title": "Machine Learning Paper",
+                }
+            ],
+        }
+        mock_response = make_httpx_response(json_data=response_data)
+
+        with patch.object(client.client, "get", new_callable=AsyncMock, return_value=mock_response):
+            url = await client.find_pdf_url(None, "Machine Learning Paper")
+
+        assert url == "https://core.ac.uk/download/pdf/67890.pdf"
+
+    async def test_find_pdf_url_no_results(self, client: CoreClient) -> None:
+        response_data = {"totalHits": 0, "results": []}
+        mock_response = make_httpx_response(json_data=response_data)
+
+        with patch.object(client.client, "get", new_callable=AsyncMock, return_value=mock_response):
+            url = await client.find_pdf_url("10.1234/nothing", None)
+
+        assert url is None
+
+    async def test_find_pdf_url_no_query(self, client: CoreClient) -> None:
+        url = await client.find_pdf_url(None, None)
+        assert url is None
+
+    async def test_find_pdf_url_server_error(self, client: CoreClient) -> None:
+        mock_response = make_httpx_response(status_code=500)
+
+        with (
+            patch.object(client.client, "get", new_callable=AsyncMock, return_value=mock_response),
+            pytest.raises(FulltextSourceError, match="CORE"),
+        ):
+            await client.find_pdf_url("10.1234/test", None)
+
+
+# --- LibgenClient tests ---
+
+
+class TestLibgenClient:
+    @pytest.fixture
+    def client(self) -> LibgenClient:
+        return LibgenClient(mirror="https://libgen.is")
+
+    async def test_find_pdf_url_success(self, client: LibgenClient) -> None:
+        html = """
+        <html><body>
+        <table class="c">
+            <tr><td><a href="/book/index.php?md5=d41d8cd98f00b204e9800998ecf8427e">Title</a></td></tr>
+        </table>
+        </body></html>
+        """
+        mock_response = make_httpx_response(
+            content=html.encode(),
+            headers={"content-type": "text/html"},
+        )
+        # Override json to return text
+        mock_response._content = html.encode()
+
+        with patch.object(client.client, "get", new_callable=AsyncMock, return_value=mock_response):
+            url = await client.find_pdf_url("Test Article Title")
+
+        assert url == "https://libgen.is/get.php?md5=d41d8cd98f00b204e9800998ecf8427e"
+
+    async def test_find_pdf_url_no_results(self, client: LibgenClient) -> None:
+        html = "<html><body><table class='c'></table></body></html>"
+        mock_response = make_httpx_response(content=html.encode())
+
+        with patch.object(client.client, "get", new_callable=AsyncMock, return_value=mock_response):
+            url = await client.find_pdf_url("Nonexistent Article")
+
+        assert url is None
+
+    async def test_find_pdf_url_server_error(self, client: LibgenClient) -> None:
+        mock_response = make_httpx_response(status_code=503)
+
+        with (
+            patch.object(client.client, "get", new_callable=AsyncMock, return_value=mock_response),
+            pytest.raises(FulltextSourceError, match="Libgen"),
+        ):
+            await client.find_pdf_url("Test")
+
+
+# --- FulltextResolver tests ---
+
+
+class TestFulltextResolver:
+    @pytest.fixture
+    def settings_all(self) -> Settings:
+        return Settings(
+            zotero_local=True,
+            unpaywall_email="test@example.com",
+            core_api_key="test-core-key",
+            fulltext_libgen_enabled=True,
+            fulltext_libgen_mirror="https://libgen.is",
+        )
+
+    @pytest.fixture
+    def settings_unpaywall_only(self) -> Settings:
+        return Settings(
+            zotero_local=True,
+            unpaywall_email="test@example.com",
+        )
+
+    @pytest.fixture
+    def settings_none(self) -> Settings:
+        return Settings(zotero_local=True)
+
+    def test_is_configured_all(self, settings_all: Settings) -> None:
+        resolver = FulltextResolver(settings_all)
+        assert resolver.is_configured is True
+
+    def test_is_configured_none(self, settings_none: Settings) -> None:
+        resolver = FulltextResolver(settings_none)
+        assert resolver.is_configured is False
+
+    def test_libgen_not_created_when_disabled(self, settings_unpaywall_only: Settings) -> None:
+        resolver = FulltextResolver(settings_unpaywall_only)
+        assert resolver._libgen is None
+        assert resolver._unpaywall is not None
+        assert resolver._core is None
+
+    async def test_cascade_unpaywall_succeeds(self, settings_all: Settings) -> None:
+        resolver = FulltextResolver(settings_all)
+        assert resolver._unpaywall is not None
+        with patch.object(
+            resolver._unpaywall, "find_pdf_url", new_callable=AsyncMock, return_value="https://pdf.com/a.pdf"
+        ):
+            url, source = await resolver.resolve("10.1234/test", "Test Title")
+
+        assert url == "https://pdf.com/a.pdf"
+        assert source == "unpaywall"
+
+    async def test_cascade_fallback_to_core(self, settings_all: Settings) -> None:
+        resolver = FulltextResolver(settings_all)
+        assert resolver._unpaywall is not None
+        assert resolver._core is not None
+        with (
+            patch.object(
+                resolver._unpaywall, "find_pdf_url", new_callable=AsyncMock, return_value=None
+            ),
+            patch.object(
+                resolver._core, "find_pdf_url", new_callable=AsyncMock, return_value="https://core.ac.uk/pdf.pdf"
+            ),
+        ):
+            url, source = await resolver.resolve("10.1234/test", "Test Title")
+
+        assert url == "https://core.ac.uk/pdf.pdf"
+        assert source == "core"
+
+    async def test_cascade_fallback_to_libgen(self, settings_all: Settings) -> None:
+        resolver = FulltextResolver(settings_all)
+        assert resolver._unpaywall is not None
+        assert resolver._core is not None
+        assert resolver._libgen is not None
+        with (
+            patch.object(
+                resolver._unpaywall, "find_pdf_url", new_callable=AsyncMock, return_value=None
+            ),
+            patch.object(
+                resolver._core, "find_pdf_url", new_callable=AsyncMock, return_value=None
+            ),
+            patch.object(
+                resolver._libgen, "find_pdf_url", new_callable=AsyncMock, return_value="https://libgen.is/get.php?md5=abc"
+            ),
+        ):
+            url, source = await resolver.resolve("10.1234/test", "Test Title")
+
+        assert url == "https://libgen.is/get.php?md5=abc"
+        assert source == "libgen"
+
+    async def test_cascade_all_fail(self, settings_all: Settings) -> None:
+        resolver = FulltextResolver(settings_all)
+        assert resolver._unpaywall is not None
+        assert resolver._core is not None
+        assert resolver._libgen is not None
+        with (
+            patch.object(
+                resolver._unpaywall, "find_pdf_url", new_callable=AsyncMock, return_value=None
+            ),
+            patch.object(
+                resolver._core, "find_pdf_url", new_callable=AsyncMock, return_value=None
+            ),
+            patch.object(
+                resolver._libgen, "find_pdf_url", new_callable=AsyncMock, return_value=None
+            ),
+            pytest.raises(FulltextNotFoundError),
+        ):
+            await resolver.resolve("10.1234/test", "Test Title")
+
+    async def test_cascade_error_continues(self, settings_all: Settings) -> None:
+        """Source errors are non-fatal — cascade continues."""
+        resolver = FulltextResolver(settings_all)
+        assert resolver._unpaywall is not None
+        assert resolver._core is not None
+        with (
+            patch.object(
+                resolver._unpaywall,
+                "find_pdf_url",
+                new_callable=AsyncMock,
+                side_effect=FulltextSourceError("Unpaywall", "timeout"),
+            ),
+            patch.object(
+                resolver._core,
+                "find_pdf_url",
+                new_callable=AsyncMock,
+                return_value="https://core.ac.uk/pdf.pdf",
+            ),
+        ):
+            url, source = await resolver.resolve("10.1234/test", "Test Title")
+
+        assert source == "core"
+
+    async def test_cascade_no_doi_skips_unpaywall(
+        self, settings_all: Settings
+    ) -> None:
+        resolver = FulltextResolver(settings_all)
+        assert resolver._core is not None
+        with patch.object(
+            resolver._core,
+            "find_pdf_url",
+            new_callable=AsyncMock,
+            return_value="https://core.ac.uk/pdf.pdf",
+        ) as mock_core:
+            url, source = await resolver.resolve(None, "Test Title")
+
+        assert source == "core"
+        mock_core.assert_called_once_with(None, "Test Title")
+
+    async def test_download_success(self, settings_all: Settings) -> None:
+        resolver = FulltextResolver(settings_all)
+        pdf_bytes = make_pdf_bytes()
+        mock_response = make_httpx_response(
+            content=pdf_bytes,
+            headers={"content-type": "application/pdf"},
+        )
+
+        with patch.object(
+            resolver._http, "get", new_callable=AsyncMock, return_value=mock_response
+        ):
+            result = await resolver.download("https://example.com/paper.pdf")
+
+        assert result == pdf_bytes
+
+    async def test_download_wrong_content_type(self, settings_all: Settings) -> None:
+        resolver = FulltextResolver(settings_all)
+        mock_response = make_httpx_response(
+            content=b"<html>Not a PDF</html>",
+            headers={"content-type": "text/html"},
+        )
+
+        with (
+            patch.object(
+                resolver._http, "get", new_callable=AsyncMock, return_value=mock_response
+            ),
+            pytest.raises(FulltextDownloadError, match="content-type"),
+        ):
+            await resolver.download("https://example.com/not-a-pdf")
+
+    async def test_download_http_error(self, settings_all: Settings) -> None:
+        resolver = FulltextResolver(settings_all)
+        mock_response = make_httpx_response(status_code=403)
+
+        with (
+            patch.object(
+                resolver._http, "get", new_callable=AsyncMock, return_value=mock_response
+            ),
+            pytest.raises(FulltextDownloadError, match="HTTP 403"),
+        ):
+            await resolver.download("https://example.com/forbidden.pdf")
+
+    def test_extract_text(self, settings_all: Settings) -> None:
+        resolver = FulltextResolver(settings_all)
+        pdf_bytes = make_pdf_bytes()
+
+        with patch("yazot.fulltext_resolver.PdfReader") as mock_reader_cls:
+            mock_page = MagicMock()
+            mock_page.extract_text.return_value = "Page 1 text"
+            mock_reader = MagicMock()
+            mock_reader.pages = [mock_page]
+            mock_reader_cls.return_value = mock_reader
+
+            text = resolver.extract_text(pdf_bytes)
+
+        assert text == "Page 1 text"
+
+    def test_extract_text_multiple_pages(self, settings_all: Settings) -> None:
+        resolver = FulltextResolver(settings_all)
+        pdf_bytes = make_pdf_bytes()
+
+        with patch("yazot.fulltext_resolver.PdfReader") as mock_reader_cls:
+            pages = []
+            for i in range(3):
+                page = MagicMock()
+                page.extract_text.return_value = f"Page {i + 1} text"
+                pages.append(page)
+            mock_reader = MagicMock()
+            mock_reader.pages = pages
+            mock_reader_cls.return_value = mock_reader
+
+            text = resolver.extract_text(pdf_bytes)
+
+        assert text == "Page 1 text\n\nPage 2 text\n\nPage 3 text"
+
+    async def test_aclose_closes_all_clients(self, settings_all: Settings) -> None:
+        resolver = FulltextResolver(settings_all)
+
+        with (
+            patch.object(resolver._http, "aclose", new_callable=AsyncMock) as mock_http,
+            patch.object(resolver._unpaywall, "aclose", new_callable=AsyncMock) as mock_unpaywall,
+            patch.object(resolver._core, "aclose", new_callable=AsyncMock) as mock_core,
+            patch.object(resolver._libgen, "aclose", new_callable=AsyncMock) as mock_libgen,
+        ):
+            await resolver.aclose()
+
+        mock_http.assert_called_once()
+        mock_unpaywall.assert_called_once()
+        mock_core.assert_called_once()
+        mock_libgen.assert_called_once()

--- a/uv.lock
+++ b/uv.lock
@@ -1637,6 +1637,7 @@ source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },
     { name = "fastmcp" },
+    { name = "httpx" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pypdf" },
@@ -1660,6 +1661,7 @@ dev = [
 requires-dist = [
     { name = "beautifulsoup4", specifier = ">=4.14.2" },
     { name = "fastmcp", specifier = ">=2.0.0,<3.0.0" },
+    { name = "httpx", specifier = ">=0.27.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pydantic-settings", specifier = ">=2.0.0" },
     { name = "pypdf", specifier = ">=4.0.0" },

--- a/yazot/config.py
+++ b/yazot/config.py
@@ -21,6 +21,12 @@ class Settings(BaseSettings):
     # so 5000 content tokens + JSON metadata overhead fits safely within that limit.
     max_chunk_size: int = Field(default=5000)
 
+    # External fulltext retrieval
+    unpaywall_email: str | None = Field(default=None)
+    core_api_key: str | None = Field(default=None)
+    fulltext_libgen_enabled: bool = Field(default=False)
+    fulltext_libgen_mirror: str = Field(default="https://libgen.is")
+
     @model_validator(mode="after")
     def validate_credentials(self) -> Self:
         """Validate credentials based on mode."""

--- a/yazot/exceptions.py
+++ b/yazot/exceptions.py
@@ -194,3 +194,40 @@ class CrossRefConnectionError(CrossReffError):
         message = f"Failed to connect to Crossref API: {detail}"
         super().__init__(message)
         self.detail = detail
+
+
+class FulltextResolverError(ToolError):
+    """Base exception for external fulltext resolution operations."""
+
+    pass
+
+
+class FulltextNotFoundError(FulltextResolverError):
+    """Raised when no external source returned a PDF."""
+
+    def __init__(self, doi: str | None, title: str | None) -> None:
+        identifier = doi or title or "unknown"
+        message = f"No fulltext found from external sources for: {identifier}"
+        super().__init__(message)
+        self.doi = doi
+        self.title = title
+
+
+class FulltextDownloadError(FulltextResolverError):
+    """Raised when PDF download or text extraction fails."""
+
+    def __init__(self, url: str, detail: str) -> None:
+        message = f"Failed to download/extract PDF from {url}: {detail}"
+        super().__init__(message)
+        self.url = url
+        self.detail = detail
+
+
+class FulltextSourceError(FulltextResolverError):
+    """Raised when an external source API returns an error."""
+
+    def __init__(self, source: str, detail: str) -> None:
+        message = f"{source} error: {detail}"
+        super().__init__(message)
+        self.source = source
+        self.detail = detail

--- a/yazot/fulltext_resolver.py
+++ b/yazot/fulltext_resolver.py
@@ -198,7 +198,7 @@ class FulltextResolver:
                 url = await self._unpaywall.find_pdf_url(doi)
                 if url:
                     return url, "unpaywall"
-            except (FulltextSourceError, httpx.RequestError) as e:
+            except FulltextSourceError as e:
                 logger.warning("Unpaywall failed for %s: %s", doi, e)
 
         if self._core and (doi or title):
@@ -206,7 +206,7 @@ class FulltextResolver:
                 url = await self._core.find_pdf_url(doi, title)
                 if url:
                     return url, "core"
-            except (FulltextSourceError, httpx.RequestError) as e:
+            except FulltextSourceError as e:
                 logger.warning("CORE failed for doi=%s title=%s: %s", doi, title, e)
 
         if title and self._libgen:
@@ -214,7 +214,7 @@ class FulltextResolver:
                 url = await self._libgen.find_pdf_url(title)
                 if url:
                     return url, "libgen"
-            except (FulltextSourceError, httpx.RequestError) as e:
+            except FulltextSourceError as e:
                 logger.warning("Libgen failed for %s: %s", title, e)
 
         raise FulltextNotFoundError(doi=doi, title=title)
@@ -230,7 +230,7 @@ class FulltextResolver:
             raise FulltextDownloadError(pdf_url, str(e)) from e
 
         content_type = response.headers.get("content-type", "")
-        if "pdf" not in content_type and not pdf_url.endswith(".pdf"):
+        if "text/html" in content_type:
             raise FulltextDownloadError(pdf_url, f"Unexpected content-type: {content_type}")
 
         if not response.content:

--- a/yazot/fulltext_resolver.py
+++ b/yazot/fulltext_resolver.py
@@ -1,0 +1,261 @@
+"""External fulltext resolver — cascading PDF retrieval from open-access sources."""
+
+import io
+import logging
+from urllib.parse import quote
+
+import httpx
+from bs4 import BeautifulSoup
+from pydantic import BaseModel, Field
+from pypdf import PdfReader
+
+from .config import Settings
+from .exceptions import FulltextDownloadError, FulltextNotFoundError, FulltextSourceError
+
+logger = logging.getLogger(__name__)
+
+
+# --- Pydantic models for API responses ---
+
+
+class UnpaywallOALocation(BaseModel):
+    url_for_pdf: str | None = None
+    url: str | None = None
+    is_best: bool = False
+
+    model_config = {"populate_by_name": True, "extra": "allow"}
+
+
+class UnpaywallWork(BaseModel):
+    doi: str
+    is_oa: bool
+    best_oa_location: UnpaywallOALocation | None = None
+    oa_locations: list[UnpaywallOALocation] = Field(default_factory=list)
+
+    model_config = {"populate_by_name": True, "extra": "allow"}
+
+
+class CoreWork(BaseModel):
+    id: int | str
+    doi: str | None = None
+    download_url: str | None = Field(None, alias="downloadUrl")
+    full_text: str | None = Field(None, alias="fullText")
+    title: str | None = None
+
+    model_config = {"populate_by_name": True, "extra": "allow"}
+
+
+class CoreSearchResponse(BaseModel):
+    total_hits: int = Field(0, alias="totalHits")
+    results: list[CoreWork] = Field(default_factory=list)
+
+    model_config = {"populate_by_name": True, "extra": "allow"}
+
+
+# --- API Clients ---
+
+
+class UnpaywallClient:
+    """Client for Unpaywall open-access PDF discovery."""
+
+    BASE_URL = "https://api.unpaywall.org/v2"
+    TIMEOUT = 30
+
+    def __init__(self, email: str) -> None:
+        self.email = email
+        self.client = httpx.AsyncClient(timeout=self.TIMEOUT)
+
+    async def find_pdf_url(self, doi: str) -> str | None:
+        """Find open-access PDF URL for a DOI via Unpaywall."""
+        url = f"{self.BASE_URL}/{quote(doi, safe='')}"
+        try:
+            response = await self.client.get(url, params={"email": self.email})
+            if response.status_code == 404:
+                return None
+            response.raise_for_status()
+            work = UnpaywallWork.model_validate(response.json())
+        except httpx.HTTPStatusError as e:
+            raise FulltextSourceError("Unpaywall", f"HTTP {e.response.status_code}") from e
+        except httpx.RequestError as e:
+            raise FulltextSourceError("Unpaywall", str(e)) from e
+
+        # Try best OA location first, then all locations
+        if work.best_oa_location and work.best_oa_location.url_for_pdf:
+            return work.best_oa_location.url_for_pdf
+        for loc in work.oa_locations:
+            if loc.url_for_pdf:
+                return loc.url_for_pdf
+        return None
+
+    async def aclose(self) -> None:
+        await self.client.aclose()
+
+
+class CoreClient:
+    """Client for CORE academic fulltext search."""
+
+    BASE_URL = "https://api.core.ac.uk/v3"
+    TIMEOUT = 30
+
+    def __init__(self, api_key: str) -> None:
+        self.client = httpx.AsyncClient(
+            timeout=self.TIMEOUT,
+            headers={"Authorization": f"Bearer {api_key}"},
+        )
+
+    async def find_pdf_url(self, doi: str | None, title: str | None) -> str | None:
+        """Search CORE for a PDF download URL."""
+        query = f'doi:"{doi}"' if doi else title
+        if not query:
+            return None
+
+        url = f"{self.BASE_URL}/search/works"
+        try:
+            response = await self.client.get(url, params={"q": query, "limit": 5})
+            if response.status_code == 404:
+                return None
+            response.raise_for_status()
+            data = CoreSearchResponse.model_validate(response.json())
+        except httpx.HTTPStatusError as e:
+            raise FulltextSourceError("CORE", f"HTTP {e.response.status_code}") from e
+        except httpx.RequestError as e:
+            raise FulltextSourceError("CORE", str(e)) from e
+
+        for work in data.results:
+            if work.download_url:
+                return work.download_url
+        return None
+
+    async def aclose(self) -> None:
+        await self.client.aclose()
+
+
+class LibgenClient:
+    """Client for Library Genesis article search (gray zone)."""
+
+    TIMEOUT = 45
+
+    def __init__(self, mirror: str) -> None:
+        self.mirror = mirror.rstrip("/")
+        self.client = httpx.AsyncClient(timeout=self.TIMEOUT, follow_redirects=True)
+
+    async def find_pdf_url(self, title: str) -> str | None:
+        """Search Libgen Sci-Tech for article PDF URL by title."""
+        search_url = f"{self.mirror}/search.php"
+        try:
+            response = await self.client.get(
+                search_url,
+                params={"req": title, "res": "25", "column": "title"},
+            )
+            response.raise_for_status()
+        except httpx.HTTPStatusError as e:
+            raise FulltextSourceError("Libgen", f"HTTP {e.response.status_code}") from e
+        except httpx.RequestError as e:
+            raise FulltextSourceError("Libgen", str(e)) from e
+
+        soup = BeautifulSoup(response.text, "html.parser")
+        # Libgen search results table contains MD5 links
+        for link in soup.select("table.c a[href*='md5=']"):
+            href = link.get("href", "")
+            if isinstance(href, str) and "md5=" in href:
+                # Extract MD5 and build direct download URL
+                md5_start = href.index("md5=") + 4
+                md5 = href[md5_start:md5_start + 32]
+                if len(md5) == 32:
+                    return f"{self.mirror}/get.php?md5={md5}"
+        return None
+
+    async def aclose(self) -> None:
+        await self.client.aclose()
+
+
+# --- Cascade Resolver ---
+
+
+class FulltextResolver:
+    """Cascading resolver: Unpaywall → CORE → Libgen (if enabled)."""
+
+    def __init__(self, settings: Settings) -> None:
+        self._unpaywall = (
+            UnpaywallClient(settings.unpaywall_email) if settings.unpaywall_email else None
+        )
+        self._core = CoreClient(settings.core_api_key) if settings.core_api_key else None
+        self._libgen = (
+            LibgenClient(settings.fulltext_libgen_mirror)
+            if settings.fulltext_libgen_enabled
+            else None
+        )
+        self._http = httpx.AsyncClient(timeout=60, follow_redirects=True)
+
+    @property
+    def is_configured(self) -> bool:
+        return any([self._unpaywall, self._core, self._libgen])
+
+    async def resolve(self, doi: str | None, title: str | None) -> tuple[str, str]:
+        """Find PDF URL through cascade. Returns (pdf_url, source_name)."""
+        if doi and self._unpaywall:
+            try:
+                url = await self._unpaywall.find_pdf_url(doi)
+                if url:
+                    return url, "unpaywall"
+            except (FulltextSourceError, httpx.RequestError) as e:
+                logger.warning("Unpaywall failed for %s: %s", doi, e)
+
+        if self._core and (doi or title):
+            try:
+                url = await self._core.find_pdf_url(doi, title)
+                if url:
+                    return url, "core"
+            except (FulltextSourceError, httpx.RequestError) as e:
+                logger.warning("CORE failed for doi=%s title=%s: %s", doi, title, e)
+
+        if title and self._libgen:
+            try:
+                url = await self._libgen.find_pdf_url(title)
+                if url:
+                    return url, "libgen"
+            except (FulltextSourceError, httpx.RequestError) as e:
+                logger.warning("Libgen failed for %s: %s", title, e)
+
+        raise FulltextNotFoundError(doi=doi, title=title)
+
+    async def download(self, pdf_url: str) -> bytes:
+        """Download PDF bytes from URL."""
+        try:
+            response = await self._http.get(pdf_url)
+            response.raise_for_status()
+        except httpx.HTTPStatusError as e:
+            raise FulltextDownloadError(pdf_url, f"HTTP {e.response.status_code}") from e
+        except httpx.RequestError as e:
+            raise FulltextDownloadError(pdf_url, str(e)) from e
+
+        content_type = response.headers.get("content-type", "")
+        if "pdf" not in content_type and not pdf_url.endswith(".pdf"):
+            raise FulltextDownloadError(pdf_url, f"Unexpected content-type: {content_type}")
+
+        if not response.content:
+            raise FulltextDownloadError(pdf_url, "Empty response body")
+
+        return response.content
+
+    def extract_text(self, pdf_bytes: bytes) -> str:
+        """Extract text from PDF bytes using pypdf."""
+        try:
+            reader = PdfReader(io.BytesIO(pdf_bytes))
+        except Exception as e:
+            raise FulltextDownloadError("pdf", f"Failed to parse PDF: {e}") from e
+        text_parts = []
+        for page in reader.pages:
+            text = page.extract_text()
+            if text:
+                text_parts.append(text)
+        return "\n\n".join(text_parts)
+
+    async def aclose(self) -> None:
+        await self._http.aclose()
+        if self._unpaywall:
+            await self._unpaywall.aclose()
+        if self._core:
+            await self._core.aclose()
+        if self._libgen:
+            await self._libgen.aclose()

--- a/yazot/mcp_server.py
+++ b/yazot/mcp_server.py
@@ -1,4 +1,8 @@
+import asyncio
 import json
+import logging
+import os
+import tempfile
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from typing import Any
@@ -9,9 +13,11 @@ from .chunker import ResponseChunker, TextChunker
 from .client_router import ZoteroClientRouter
 from .config import Settings
 from .crossref_client import CrossrefClient
-from .exceptions import ZoteroError, ZoteroNotFoundError
+from .exceptions import ConfigurationError, ZoteroError, ZoteroNotFoundError
+from .fulltext_resolver import FulltextResolver
 from .models import (
     CollectionCreate,
+    ExternalFulltextResponse,
     FulltextResponse,
     Note,
     SearchCollectionResponse,
@@ -23,6 +29,8 @@ from .models import (
 )
 from .note_manager import NoteManager
 from .verifier import NoteVerifier
+
+logger = logging.getLogger(__name__)
 
 
 def _deps(ctx: Context) -> dict[str, Any]:
@@ -41,6 +49,7 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[dict[str, Any]]:
     text_chunker = TextChunker(max_tokens=settings.max_chunk_size)
     note_manager = NoteManager(router)
     verifier = NoteVerifier(note_manager, router)
+    resolver = FulltextResolver(settings)
 
     try:
         yield {
@@ -51,9 +60,11 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[dict[str, Any]]:
             "text_chunker": text_chunker,
             "note_manager": note_manager,
             "verifier": verifier,
+            "resolver": resolver,
         }
     finally:
         await crossref.aclose()
+        await resolver.aclose()
 
 
 # Create FastMCP server with error masking for security
@@ -76,6 +87,10 @@ mcp: FastMCP = FastMCP(
 ### Fulltext Access
 - `get_item_fulltext(item_key)`: Get PDF text (tries indexed API, falls back to direct parsing)
   - Returns chunked text (use `get_next_fulltext_chunk` if `has_more=True`)
+- `fetch_external_fulltext(item_key, doi, title)`: Search external sources for fulltext
+  - Cascade: Unpaywall → CORE → Libgen (if enabled)
+  - If `item_key` provided: extracts DOI/title automatically, attaches PDF to item
+  - Use when `get_item_fulltext` returns no content
 - `get_next_fulltext_chunk(chunk_id)`: Continue retrieving text chunks
 
 ### Notes
@@ -112,6 +127,12 @@ mcp: FastMCP = FastMCP(
 2. If `has_more=True`, call `get_next_chunk(chunk_id)` repeatedly
 3. For specific item, call `get_item_fulltext(item_key)`
 4. If fulltext `has_more=True`, call `get_next_fulltext_chunk(chunk_id)` repeatedly
+
+**Fetch fulltext from external sources:**
+1. `fetch_external_fulltext(item_key="ABC123")` — uses DOI from item, attaches PDF
+2. Or `fetch_external_fulltext(doi="10.1234/example")` — standalone search by DOI
+3. Or `fetch_external_fulltext(title="Article title")` — search by title
+4. If `has_more=True`, call `get_next_fulltext_chunk(chunk_id)` repeatedly
 
 **Add article by DOI:**
 1. `add_item_by_doi(doi="10.1234/example", collection_key="ABC123", tags=["important"])`
@@ -570,6 +591,138 @@ async def verify_note(note_key: str, ctx: Context) -> VerificationResult:
     """
     verifier: NoteVerifier = _deps(ctx)["verifier"]
     return await verifier.verify(note_key)
+
+
+@mcp.tool
+async def fetch_external_fulltext(
+    ctx: Context,
+    item_key: str | None = None,
+    doi: str | None = None,
+    title: str | None = None,
+) -> ExternalFulltextResponse:
+    """
+    Fetch full text of an article from external open-access sources.
+
+    Searches external sources in cascade order:
+    1. Unpaywall (by DOI) - legal open-access repository
+    2. CORE (by DOI or title) - academic aggregator
+    3. Libgen (by title) - only if explicitly enabled in config
+
+    If item_key is provided, DOI/title are extracted from the Zotero item automatically,
+    and the downloaded PDF is attached to the item.
+
+    At least one of item_key, doi, or title must be provided.
+
+    Args:
+        item_key: Optional Zotero item key — extracts DOI/title and attaches PDF
+        doi: DOI identifier (preferred for best results)
+        title: Article title (used for CORE and libgen search)
+
+    Returns:
+        ExternalFulltextResponse with extracted text content (potentially chunked)
+
+    IMPORTANT CHUNKING BEHAVIOR:
+    - If response contains 'has_more=True', there are more text chunks
+    - Call 'get_next_fulltext_chunk' with the provided 'chunk_id'
+    - Continue calling until 'has_more=False'
+    """
+    resolver: FulltextResolver = _deps(ctx)["resolver"]
+    router: ZoteroClientRouter = _deps(ctx)["router"]
+    text_chunker: TextChunker = _deps(ctx)["text_chunker"]
+
+    if not resolver.is_configured:
+        raise ConfigurationError(
+            "External fulltext retrieval is not configured. "
+            "Set UNPAYWALL_EMAIL and/or CORE_API_KEY in .env"
+        )
+
+    # Extract DOI/title from Zotero item if item_key provided
+    effective_doi = doi
+    effective_title = title
+    if item_key:
+        item = await router.get_item(item_key)
+        if not effective_doi:
+            effective_doi = item.data.doi or None
+        if not effective_title:
+            effective_title = item.data.title or None
+
+    if not effective_doi and not effective_title:
+        raise ZoteroError("At least one of doi or title must be provided or resolvable from item")
+
+    # Resolve PDF URL through cascade
+    pdf_url, source = await resolver.resolve(effective_doi, effective_title)
+
+    # Download and extract text
+    pdf_bytes = await resolver.download(pdf_url)
+    text = resolver.extract_text(pdf_bytes)
+
+    if not text.strip():
+        return ExternalFulltextResponse(
+            item_key=item_key,
+            content="",
+            source=source,
+            error="PDF downloaded but no text could be extracted",
+        )
+
+    # Attach PDF to Zotero item if item_key provided
+    pdf_attached = False
+    if item_key:
+        pdf_attached = await _attach_pdf_to_item(ctx, item_key, pdf_bytes)
+
+    # Chunk if needed (reuse existing TextChunker + get_next_fulltext_chunk)
+    chunk_key = item_key or effective_doi or effective_title or "external"
+    if not text_chunker.needs_chunking(text):
+        return ExternalFulltextResponse(
+            item_key=item_key,
+            content=text,
+            source=source,
+            pdf_attached=pdf_attached,
+        )
+
+    chunk_data = text_chunker.chunk_text(text, chunk_key)
+    message = None
+    if chunk_data.has_more:
+        message = (
+            f"Fulltext chunked ({chunk_data.chunk_info}). "
+            f"To get remaining text, call: "
+            f"get_next_fulltext_chunk(chunk_id='{chunk_data.chunk_id}')"
+        )
+
+    return ExternalFulltextResponse(
+        item_key=item_key,
+        content=chunk_data.content,
+        source=source,
+        pdf_attached=pdf_attached,
+        has_more=chunk_data.has_more,
+        chunk_id=chunk_data.chunk_id,
+        current_chunk=chunk_data.current_chunk,
+        total_chunks=chunk_data.total_chunks,
+        message=message,
+    )
+
+
+async def _attach_pdf_to_item(ctx: Context, item_key: str, pdf_bytes: bytes) -> bool:
+    """Attempt to attach PDF to a Zotero item. Returns True if successful."""
+    router: ZoteroClientRouter = _deps(ctx)["router"]
+    try:
+        write_client = router.write_client
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
+            f.write(pdf_bytes)
+            tmp_path = f.name
+        try:
+            await asyncio.to_thread(
+                write_client._client.attachment_simple,
+                [tmp_path],
+                item_key,
+            )
+            return True
+        finally:
+            os.unlink(tmp_path)
+    except Exception as e:
+        logger.warning(
+            "PDF attachment failed for item %s: %s", item_key, e
+        )
+        return False
 
 
 @mcp.resource("resource://collections")

--- a/yazot/models.py
+++ b/yazot/models.py
@@ -234,6 +234,17 @@ class FulltextResponse(ChunkInfoMixin):
     error: str | None = None
 
 
+class ExternalFulltextResponse(ChunkInfoMixin):
+    """Response for externally fetched fulltext content."""
+
+    item_key: str | None = None
+    content: str
+    source: str | None = None
+    pdf_attached: bool = False
+    message: str | None = None
+    error: str | None = None
+
+
 class ChunkResponse(ChunkInfoMixin):
     items: list[ZoteroItem]
     error: str | None = None


### PR DESCRIPTION
## Summary
- Cascading fulltext search: Unpaywall (by DOI) → CORE API (by DOI/title) → Libgen (by title, opt-in)
- Downloads PDF, extracts text via pypdf, optionally attaches PDF to Zotero item
- Libgen isolated by config flag (`FULLTEXT_LIBGEN_ENABLED=false` by default)

## Summary by Sourcery

Add external open-access fulltext retrieval with cascading resolution and integration into the MCP server, including optional PDF attachment to Zotero items.

New Features:
- Expose a fetch_external_fulltext MCP tool that retrieves article PDFs from external sources and returns extracted text, optionally attaching the PDF to a Zotero item.
- Introduce a cascading FulltextResolver that queries Unpaywall, CORE, and optionally Libgen to locate open-access PDFs.
- Add configuration options for external fulltext providers, including Unpaywall email, CORE API key, and a toggle plus mirror for Libgen access.

Enhancements:
- Extend MCP server lifespan dependencies to manage the FulltextResolver lifecycle and expose it to tools.
- Define an ExternalFulltextResponse model to standardize responses for externally fetched fulltext content.

Build:
- Add httpx as a dependency for external HTTP-based fulltext resolution.

Tests:
- Add unit tests for Unpaywall, CORE, and Libgen clients as well as the FulltextResolver cascade, download, extraction, and shutdown behavior.
- Add end-to-end tests for the fetch_external_fulltext MCP tool, including configuration, error paths, and chunked retrieval via get_next_fulltext_chunk.