### PR TITLE
refactor: eliminate duplicate API calls in fulltext retrieval

### DIFF
--- a/.claude/rules/concurrency.md
+++ b/.claude/rules/concurrency.md
@@ -1,0 +1,10 @@
+---
+globs: ["yazot/**/*.py"]
+---
+# Concurrency patterns
+
+- `ZoteroClient._call` and `Collection._call` wrap all pyzotero calls with an optional `asyncio.Semaphore`
+- Semaphore is created in `ZoteroClient.__init__` only for web mode (`Settings.web_zotero_max_concurrent_requests`)
+- Local mode: semaphore is `None`, no rate limiting
+- All `Collection` instances receive the semaphore from `ZoteroClient` — rate limit is global per client
+- When adding new parallel operations: do NOT create local semaphores — rely on the client-level one in `_call`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,7 @@ For tests: `.env.test` (auto-loaded via `conftest.py`)
 - All models — Pydantic v2 BaseModel (not dicts)
 - Tests: mocks via `unittest.mock`, fixtures in `conftest.py`, pytest-asyncio (`asyncio_mode="auto"`)
 - All MCP tools and I/O are async
+- Commit messages, PR titles/body, code comments — always in English
 - Errors: custom exceptions from `exceptions.py`, never bare Exception
 - `ZoteroItemData.doi` can be `""` (empty string), not just `None` — normalize via `or None`
 - PDF attachment: `router.attach_pdf(item_key, filepath)` — NOT via `_client` directly

--- a/tests/test_client_router.py
+++ b/tests/test_client_router.py
@@ -1,5 +1,7 @@
 """Tests for ZoteroClientRouter and webonly decorator."""
 
+from unittest.mock import AsyncMock, patch
+
 import pytest
 
 from yazot.client_router import ZoteroClientRouter
@@ -168,3 +170,104 @@ class TestZoteroClientProtocolImplementation:
         if router.has_local_client:
             # Cache should come from read_client
             assert router.cache is router.read_client.cache
+
+
+class TestRouterGetItemFulltext:
+    """Test get_item_fulltext routing and fallback logic."""
+
+    @staticmethod
+    def _make_hybrid_router() -> ZoteroClientRouter:
+        settings = Settings(zotero_local=True, zotero_library_id="1")
+        router = ZoteroClientRouter(settings=settings)
+        if not router._local_client or not router._web_client:
+            pytest.skip("Need both local and web clients for hybrid tests")
+        return router
+
+    @pytest.mark.asyncio
+    async def test_returns_read_client_result_without_web_fallback(self) -> None:
+        """When read_client returns text, web_client is never called."""
+        router = self._make_hybrid_router()
+
+        with (
+            patch.object(
+                router.read_client,
+                "get_item_fulltext",
+                new_callable=AsyncMock,
+                return_value="local text",
+            ),
+            patch.object(
+                router._web_client,  # type: ignore[union-attr]
+                "get_item_fulltext",
+                new_callable=AsyncMock,
+            ) as web_mock,
+        ):
+            result = await router.get_item_fulltext("KEY")
+
+        assert result == "local text"
+        web_mock.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_web_when_read_returns_none(self) -> None:
+        """When read_client returns None, falls back to web_client."""
+        router = self._make_hybrid_router()
+
+        with (
+            patch.object(
+                router.read_client,
+                "get_item_fulltext",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch.object(
+                router._web_client,  # type: ignore[union-attr]
+                "get_item_fulltext",
+                new_callable=AsyncMock,
+                return_value="web text",
+            ) as web_mock,
+        ):
+            result = await router.get_item_fulltext("KEY")
+
+        assert result == "web text"
+        web_mock.assert_called_once_with("KEY")
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_web_when_read_raises(self) -> None:
+        """When read_client raises, falls back to web_client."""
+        router = self._make_hybrid_router()
+
+        with (
+            patch.object(
+                router.read_client,
+                "get_item_fulltext",
+                new_callable=AsyncMock,
+                side_effect=Exception("connection refused"),
+            ),
+            patch.object(
+                router._web_client,  # type: ignore[union-attr]
+                "get_item_fulltext",
+                new_callable=AsyncMock,
+                return_value="web text",
+            ) as web_mock,
+        ):
+            result = await router.get_item_fulltext("KEY")
+
+        assert result == "web text"
+        web_mock.assert_called_once_with("KEY")
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_single_client_has_no_fulltext(self) -> None:
+        """With only one client, returns None if it has no fulltext."""
+        settings = Settings(zotero_local=True, zotero_library_id="1")
+        router = ZoteroClientRouter(settings=settings)
+        # Force single-client mode
+        router._web_client = None
+
+        with patch.object(
+            router.read_client,
+            "get_item_fulltext",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            result = await router.get_item_fulltext("KEY")
+
+        assert result is None

--- a/tests/test_client_router.py
+++ b/tests/test_client_router.py
@@ -134,6 +134,7 @@ class TestZoteroClientProtocolImplementation:
             "get_children",
             "get_fulltext",
             "get_pdf_text",
+            "get_item_fulltext",
             "get_items",
             "get_collections",
         ]

--- a/yazot/client_router.py
+++ b/yazot/client_router.py
@@ -274,6 +274,20 @@ class ZoteroClientRouter(ZoteroClientProtocol):
 
         return None
 
+    async def get_item_fulltext(self, item_key: str) -> str | None:
+        """Get fulltext (indexed API + PDF fallback) with local→web routing."""
+        try:
+            result = await self.read_client.get_item_fulltext(item_key)
+            if result:
+                return result
+        except Exception:
+            pass
+
+        if self._local_client and self._web_client:
+            return await self._web_client.get_item_fulltext(item_key)
+
+        return None
+
     async def search_items(self, search_params: "ZoteroSearchParams") -> list["ZoteroItem"]:
         """Search items across library (read operation with fallback)."""
         try:

--- a/yazot/protocols.py
+++ b/yazot/protocols.py
@@ -127,6 +127,13 @@ class ZoteroClientProtocol(Protocol):
         """Get text by downloading and parsing PDF directly."""
         ...
 
+    async def get_item_fulltext(self, item_key: str) -> str | None:
+        """Get fulltext: try indexed API first, then PDF parsing fallback.
+
+        Finds PDF attachment once and reuses for both methods.
+        """
+        ...
+
     async def search_items(self, search_params: ZoteroSearchParams) -> list["ZoteroItem"]:
         """Search items across entire library with Zotero API parameters.
 

--- a/yazot/verifier.py
+++ b/yazot/verifier.py
@@ -53,10 +53,7 @@ class NoteVerifier:
 
     async def _get_fulltext(self, item_key: str) -> str | None:
         """Get fulltext for item, trying indexed API then PDF fallback."""
-        fulltext = await self.client.get_fulltext(item_key)
-        if not fulltext:
-            fulltext = await self.client.get_pdf_text(item_key)
-        return fulltext
+        return await self.client.get_item_fulltext(item_key)
 
     async def _add_tag_to_note(self, note_key: str, tag: str) -> None:
         """Add a tag to a note, preserving existing tags."""

--- a/yazot/zotero_client.py
+++ b/yazot/zotero_client.py
@@ -235,12 +235,21 @@ class ZoteroClient(ZoteroClientProtocol):
     async def _find_pdf_attachment_key(self, item_key: str) -> str | None:
         """Find PDF attachment key: check if item itself is PDF, otherwise search children.
 
+        Results are cached to avoid repeated API calls when multiple methods
+        need the same PDF key (e.g. fulltext API → PDF parsing fallback).
+
         Args:
             item_key: Item key (can be parent item or attachment itself)
 
         Returns:
             PDF attachment key, or None if no PDF found
         """
+        cache_key = f"pdf_key:{item_key}"
+        if cache_key in self._cache:
+            return self._cache[cache_key]  # type: ignore[no-any-return]
+
+        result: str | None = None
+
         # Check if item itself is a PDF attachment
         try:
             raw_item = await _run_sync(self._client.item, item_key)
@@ -249,17 +258,20 @@ class ZoteroClient(ZoteroClientProtocol):
                 item_data.get("itemType") == "attachment"
                 and item_data.get("contentType") == "application/pdf"
             ):
-                return item_key
+                result = item_key
         except Exception:
             pass
 
         # Otherwise search children for PDF attachment
-        children = await self.get_children(item_key)
-        for child in children:
-            if child.content_type == "application/pdf":
-                return child.key
+        if result is None:
+            children = await self.get_children(item_key)
+            for child in children:
+                if child.content_type == "application/pdf":
+                    result = child.key
+                    break
 
-        return None
+        self._cache[cache_key] = result
+        return result
 
     async def get_fulltext(self, item_key: str) -> str | None:
         """Get full text content from PDF attachment of an item.
@@ -341,6 +353,55 @@ class ZoteroClient(ZoteroClientProtocol):
             # Transient error (network, PDF parsing) — do NOT cache, allow retry
             logger.warning("Failed to get PDF text for item %s", item_key, exc_info=True)
 
+        return None
+
+    async def get_item_fulltext(self, item_key: str) -> str | None:
+        """Get fulltext for item: try indexed API first, then PDF parsing fallback.
+
+        Finds PDF attachment key once and reuses it for both extraction methods,
+        avoiding duplicate API calls.
+
+        Args:
+            item_key: Item key (parent item or PDF attachment itself)
+
+        Returns:
+            Text content, or None if not available
+        """
+        cache_key = f"item_fulltext:{item_key}"
+        if cache_key in self._cache:
+            cached = self._cache[cache_key]
+            return cached if isinstance(cached, str) else None
+
+        pdf_key = await self._find_pdf_attachment_key(item_key)
+        if not pdf_key:
+            self._cache[cache_key] = None
+            return None
+
+        # 1. Try Zotero's indexed fulltext API (fast)
+        try:
+            fulltext_data = await _run_sync(self._client.fulltext_item, pdf_key)
+            content = fulltext_data.get("content")
+            if content:
+                self._cache[cache_key] = str(content)
+                return str(content)
+        except (zotero_errors.ResourceNotFoundError, KeyError, ValueError):
+            pass
+        except Exception:
+            logger.warning("Failed to get indexed fulltext for %s", item_key, exc_info=True)
+
+        # 2. Fallback: download and parse PDF directly
+        try:
+            pdf_bytes = await _run_sync(self._client.file, pdf_key)
+            text = extract_text_from_pdf(pdf_bytes)
+            if text:
+                self._cache[cache_key] = text
+                return text
+        except (zotero_errors.ResourceNotFoundError, KeyError, ValueError):
+            pass
+        except Exception:
+            logger.warning("Failed to parse PDF for %s", item_key, exc_info=True)
+
+        self._cache[cache_key] = None
         return None
 
     async def get_item(self, item_key: str) -> ZoteroItem:
@@ -673,8 +734,7 @@ class ZoteroClient(ZoteroClientProtocol):
             ) from e
         except Exception as e:
             raise ZoteroError(
-                f"Unexpected error attaching PDF to item '{item_key}': "
-                f"{type(e).__name__}: {e}"
+                f"Unexpected error attaching PDF to item '{item_key}': " f"{type(e).__name__}: {e}"
             ) from e
 
     @webonly


### PR DESCRIPTION
## Summary

- Add unified `get_item_fulltext()` method that finds PDF attachment key once and tries both indexed API and PDF parsing fallback — eliminates the duplicated `get_fulltext() → get_pdf_text()` pattern in `mcp_server` and `verifier`
- Cache `_find_pdf_attachment_key` results to prevent repeated lookups within the same client
- In hybrid mode worst case: 8 API calls instead of 12 (33% reduction)

## Summary by Sourcery

Introduce a unified fulltext retrieval API that avoids redundant Zotero calls and centralizes fallback logic.

New Features:
- Add get_item_fulltext API on the Zotero client to retrieve fulltext via indexed API with PDF parsing fallback.
- Expose get_item_fulltext through the client router with local→web fallback behavior.

Enhancements:
- Cache PDF attachment key lookups to reduce repeated API calls when resolving item fulltext.
- Extend the Zotero client protocol and verifier to use the new unified fulltext retrieval method instead of duplicating logic.
- Minor formatting cleanup in Zotero error handling messages.

Tests:
- Update client router protocol method coverage test to include get_item_fulltext.