### PR TITLE
chore: fix dev dependencies, add concurrency and mypy rules

### DIFF
--- a/.claude/rules/concurrency.md
+++ b/.claude/rules/concurrency.md
@@ -1,0 +1,10 @@
+---
+globs: ["yazot/**/*.py"]
+---
+# Concurrency patterns
+
+- `ZoteroClient._call` and `Collection._call` wrap all pyzotero calls with an optional `asyncio.Semaphore`
+- Semaphore is created in `ZoteroClient.__init__` only for web mode (`Settings.web_zotero_max_concurrent_requests`)
+- Local mode: semaphore is `None`, no rate limiting
+- All `Collection` instances receive the semaphore from `ZoteroClient` — rate limit is global per client
+- When adding new parallel operations: do NOT create local semaphores — rely on the client-level one in `_call`

--- a/.claude/rules/mypy-patterns.md
+++ b/.claude/rules/mypy-patterns.md
@@ -11,3 +11,18 @@ Use early return/raise for each check separately, or an explicit annotation:
 
 Pydantic `@computed_field` is not supported by the mypy pydantic plugin as a property.
 For type-safe access use `item.data.field` instead of `item.field`.
+
+# asyncio.gather(return_exceptions=True)
+
+Return type is `list[T | BaseException]`. mypy does not narrow via `isinstance(result, Exception)`.
+Use `isinstance(result, BaseException)` for narrowing, then separate Exception from non-Exception:
+
+```python
+for result in results:
+    if isinstance(result, BaseException):
+        if not isinstance(result, Exception):
+            raise result  # CancelledError, KeyboardInterrupt
+        logger.warning("...", result)
+        continue
+    # here result is narrowed to T
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,7 @@ For tests: `.env.test` (auto-loaded via `conftest.py`)
 - All models — Pydantic v2 BaseModel (not dicts)
 - Tests: mocks via `unittest.mock`, fixtures in `conftest.py`, pytest-asyncio (`asyncio_mode="auto"`)
 - All MCP tools and I/O are async
+- Commit messages, PR titles/body, code comments — always in English
 - Errors: custom exceptions from `exceptions.py`, never bare Exception
 - `ZoteroItemData.doi` can be `""` (empty string), not just `None` — normalize via `or None`
 - PDF attachment: `router.attach_pdf(item_key, filepath)` — NOT via `_client` directly

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,17 +15,6 @@ dependencies = [
     "beautifulsoup4>=4.14.2",
 ]
 
-[project.optional-dependencies]
-dev = [
-    "pytest>=7.0.0",
-    "pytest-asyncio>=0.21.0",
-    "pytest-cov>=4.0.0",
-    "ruff>=0.6.0",
-    "mypy>=1.18.2",
-    "black>=24.8.0",
-    "pre-commit>=3.8.0",
-]
-
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
@@ -80,5 +69,12 @@ target-version = ['py312']
 
 [dependency-groups]
 dev = [
+    "pytest>=7.0.0",
+    "pytest-asyncio>=0.21.0",
+    "pytest-cov>=4.0.0",
+    "ruff>=0.6.0",
+    "mypy>=1.18.2",
+    "black>=24.8.0",
+    "pre-commit>=3.8.0",
     "ipython>=8.0.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1926,9 +1926,10 @@ dependencies = [
     { name = "pyzotero" },
 ]
 
-[package.optional-dependencies]
+[package.dev-dependencies]
 dev = [
     { name = "black" },
+    { name = "ipython" },
     { name = "mypy" },
     { name = "pre-commit" },
     { name = "pytest" },
@@ -1937,33 +1938,29 @@ dev = [
     { name = "ruff" },
 ]
 
-[package.dev-dependencies]
-dev = [
-    { name = "ipython" },
-]
-
 [package.metadata]
 requires-dist = [
     { name = "beautifulsoup4", specifier = ">=4.14.2" },
-    { name = "black", marker = "extra == 'dev'", specifier = ">=24.8.0" },
     { name = "fastmcp", specifier = ">=2.0.0,<3.0.0" },
     { name = "httpx", specifier = ">=0.27.0" },
-    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.18.2" },
-    { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.8.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pydantic-settings", specifier = ">=2.0.0" },
     { name = "pypdf", specifier = ">=4.0.0" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
-    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
-    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "pyzotero", specifier = ">=1.11.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6.0" },
 ]
-provides-extras = ["dev"]
 
 [package.metadata.requires-dev]
-dev = [{ name = "ipython", specifier = ">=8.0.0" }]
+dev = [
+    { name = "black", specifier = ">=24.8.0" },
+    { name = "ipython", specifier = ">=8.0.0" },
+    { name = "mypy", specifier = ">=1.18.2" },
+    { name = "pre-commit", specifier = ">=3.8.0" },
+    { name = "pytest", specifier = ">=7.0.0" },
+    { name = "pytest-asyncio", specifier = ">=0.21.0" },
+    { name = "pytest-cov", specifier = ">=4.0.0" },
+    { name = "ruff", specifier = ">=0.6.0" },
+]
 
 [[package]]
 name = "zipp"


### PR DESCRIPTION
## Summary

- Consolidate dev deps from `[project.optional-dependencies]` into `[dependency-groups]` so `uv sync --group dev` installs all tools (ruff, mypy, black, pytest) — fixes broken WorktreeCreate hook
- Add `asyncio.gather(return_exceptions=True)` mypy narrowing pattern to `.claude/rules/mypy-patterns.md`
- Add `.claude/rules/concurrency.md` documenting client-level semaphore architecture
- Add English-only convention for commits/PRs/comments to `CLAUDE.md`