### PR TITLE
fix(tests): update 11 tests for FastMCP 2.x API changes

### DIFF
--- a/tests/test_doi.py
+++ b/tests/test_doi.py
@@ -2,13 +2,14 @@
 
 import pytest
 from fastmcp import Client
+from fastmcp.exceptions import ToolError
 
+from tests.test_helpers import ZoteroTestDataManager
 from yazot.crossref_client import CrossrefClient, CrossrefWork
-from yazot.exceptions import DOINotFoundError, InvalidDOIError, ZoteroNotFoundError
+from yazot.exceptions import DOINotFoundError, InvalidDOIError
 from yazot.mcp_server import mcp
 from yazot.models import ItemCreate
 from yazot.zotero_client import ZoteroClient
-from tests.test_helpers import ZoteroTestDataManager
 
 
 class TestCrossrefClient:
@@ -232,7 +233,7 @@ class TestAddItemByDOI:
         invalid_doi = "not-a-valid-doi"
 
         async with Client(mcp) as client:
-            with pytest.raises(ZoteroNotFoundError):  # Should raise ZoteroNotFoundError
+            with pytest.raises(ToolError, match="DOI must start with"):
                 await client.call_tool(
                     "add_item_by_doi",
                     arguments={"doi": invalid_doi},

--- a/tests/test_e2e_search.py
+++ b/tests/test_e2e_search.py
@@ -51,7 +51,7 @@ class TestSearchE2E:
         async with Client(mcp) as client:
             result = await client.call_tool(
                 "get_collection_items",
-                arguments={"collection_key": collection_key, "include_fulltext": True},
+                arguments={"collection_key": collection_key},
             )
             response = result.data
 
@@ -73,7 +73,7 @@ class TestSearchE2E:
         async with Client(mcp) as client:
             result = await client.call_tool(
                 "get_collection_items",
-                arguments={"collection_key": collection_key, "include_fulltext": True},
+                arguments={"collection_key": collection_key},
             )
             response = result.data
 
@@ -107,7 +107,7 @@ class TestSearchE2E:
         chunker = ResponseChunker(max_tokens=18000)
         response_json = json.dumps(
             {
-                "items": [item.model_dump() for item in response.items],
+                "items": [vars(item) for item in response.items],
                 "count": response.count,
                 "has_more": response.has_more,
                 "chunk_id": response.chunk_id,
@@ -151,7 +151,7 @@ class TestSearchE2E:
         chunker = ResponseChunker(max_tokens=18000)
         response_json = json.dumps(
             {
-                "items": [item.model_dump() for item in response.items],
+                "items": [vars(item) for item in response.items],
                 "count": response.count,
                 "has_more": response.has_more,
                 "chunk_id": response.chunk_id,
@@ -188,7 +188,7 @@ class TestSearchE2E:
             # Check first chunk
             response_json = json.dumps(
                 {
-                    "items": [item.model_dump() for item in response.items],
+                    "items": [vars(item) for item in response.items],
                     "count": response.count,
                     "has_more": response.has_more,
                     "chunk_id": response.chunk_id,
@@ -212,7 +212,7 @@ class TestSearchE2E:
                 # Check each chunk
                 response_json = json.dumps(
                     {
-                        "items": [item.model_dump() for item in response.items],
+                        "items": [vars(item) for item in response.items],
                         "count": response.count,
                         "has_more": response.has_more,
                         "chunk_id": response.chunk_id,

--- a/tests/test_server_startup.py
+++ b/tests/test_server_startup.py
@@ -23,7 +23,7 @@ class TestMCPServerStartup:
     async def test_mcp_tools_registered(self) -> None:
         """Test that all required tools are registered."""
         # Get registered tool names
-        tool_names = [tool.name for tool in await mcp._list_tools()]
+        tool_names = list((await mcp.get_tools()).keys())
 
         # Verify all expected tools are registered
         expected_tools = [
@@ -41,7 +41,7 @@ class TestMCPServerStartup:
     async def test_mcp_resources_registered(self) -> None:
         """Test that all required resources are registered."""
         # Get registered resource URIs (convert to string for comparison)
-        resource_uris = [str(resource.uri) for resource in await mcp._list_resources()]
+        resource_uris = [str(r.uri) for r in (await mcp.get_resources()).values()]
 
         # Verify expected resources are registered
         expected_resources = [
@@ -57,7 +57,7 @@ class TestMCPServerStartup:
         """Test that server has correct metadata."""
         assert mcp.name == "zotero-mcp"
         # Verify tools have descriptions
-        tools = await mcp._list_tools()
+        tools = (await mcp.get_tools()).values()
         for tool in tools:
             assert tool.description, f"Tool {tool.name} has no description"
 

--- a/tests/test_subcollections.py
+++ b/tests/test_subcollections.py
@@ -150,21 +150,23 @@ class TestSubcollections:
             )
             response = result.data
 
-        # With small chunk size, chunking should be triggered
-        if response.has_more:
-            assert response.chunk_id
-            assert response.current_chunk is not None
-            assert response.total_chunks is not None
+            # With small chunk size, chunking should be triggered
+            if response.has_more:
+                assert response.chunk_id
+                assert response.current_chunk is not None
+                assert response.total_chunks is not None
 
-            # Collect all chunks
-            all_items = list(response.items)
-            chunk_id = response.chunk_id
-
-            while response.has_more:
-                result = await client.call_tool("get_next_chunk", arguments={"chunk_id": chunk_id})
-                response = result.data
-                all_items.extend(response.items)
+                # Collect all chunks
+                all_items = list(response.items)
                 chunk_id = response.chunk_id
 
-            # Total should match expected
-            assert len(all_items) == expected_total
+                while response.has_more:
+                    result = await client.call_tool(
+                        "get_next_chunk", arguments={"chunk_id": chunk_id}
+                    )
+                    response = result.data
+                    all_items.extend(response.items)
+                    chunk_id = response.chunk_id
+
+                # Total should match expected
+                assert len(all_items) == expected_total

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -105,13 +105,16 @@ class TestTagsE2E:
     ) -> None:
         """Test creating note with tags through create_note_for_item endpoint."""
 
-        # Use first test item
-        collection = await test_zotero_client.get_collection(key=collection_key_items_with_tags)
-        assert collection is not None
-        item_key = collection.items.all()[0].key
         note_tags = ["test-note-tag", "automated"]
 
         async with Client(mcp) as client:
+            # Get first item from collection
+            items_result = await client.call_tool(
+                "get_collection_items",
+                arguments={"collection_key": collection_key_items_with_tags},
+            )
+            item_key = items_result.data.items[0].key
+
             result = await client.call_tool(
                 "create_note_for_item",
                 arguments={


### PR DESCRIPTION
## Summary
- Fixes 11 broken tests caused by FastMCP 2.x API changes: private methods removed, `include_fulltext` parameter deleted, MCP Client returns Root objects instead of Pydantic models, tool errors wrapped in `ToolError`
- Also fixes `Collection.items` access (attribute doesn't exist) and chunk iteration outside Client context manager

## Summary by Sourcery

Update tests to align with FastMCP 2.x API changes and new error and response behaviors.

Bug Fixes:
- Fix chunked subcollection test to perform all chunk retrieval within the client context manager and correctly track chunk IDs.
- Remove deprecated include_fulltext argument from collection item retrieval tests to match the updated tool signature.
- Adjust tests to serialize collection items using plain objects now that the MCP client returns non-Pydantic models.
- Update DOI-related tests to expect ToolError wrapping for invalid DOI errors.
- Fix server startup tests to use the new public tool and resource listing APIs and structures.
- Update tag-related test to fetch collection items through the MCP client instead of using a non-existent collection.items attribute.

Tests:
- Refresh end-to-end search, chunking, DOI, tags, subcollections, and server startup tests to be compatible with FastMCP 2.x behavior and interfaces.