### PR TITLE
fix(tests): work around FastMCP lifespan cleanup bug in test_doi

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,9 +9,10 @@ from unittest.mock import MagicMock, patch
 import httpx
 import pytest
 from dotenv import load_dotenv
-from fastmcp import Context
+from fastmcp import Client, Context
 
 from yazot.config import Settings
+from yazot.mcp_server import mcp
 from yazot.models import ZoteroItem
 from yazot.zotero_client import ZoteroClient
 
@@ -195,6 +196,27 @@ async def mcp_context(test_settings: Settings) -> Context:
     )
 
     return Context(server)
+
+
+# WORKAROUND: FastMCP lifespan cleanup bug
+# FastMCP 2.x (and 3.x) never resets _lifespan_result_set after Client
+# disconnects because the cleanup code in _lifespan_manager() is unreachable
+# due to anyio task group cancellation.  This causes subsequent Client(mcp)
+# sessions to reuse stale lifespan context with already-closed resources.
+# Reproduction & details: ~/Projects/fastmcp-lifespan-issue/
+# TODO: remove when FastMCP fixes _lifespan_manager() cleanup
+@pytest.fixture(autouse=True)
+def _reset_mcp_lifespan() -> None:
+    """Force FastMCP to create a fresh lifespan on each test."""
+    mcp._lifespan_result_set = False
+    mcp._lifespan_result = None
+
+
+@pytest.fixture
+async def mcp_client() -> AsyncGenerator[Client, None]:
+    """Per-test MCP client — all tool calls in one test go through this."""
+    async with Client(mcp) as client:
+        yield client
 
 
 @pytest.fixture(scope="function")

--- a/tests/test_doi.py
+++ b/tests/test_doi.py
@@ -7,7 +7,6 @@ from fastmcp.exceptions import ToolError
 from tests.test_helpers import ZoteroTestDataManager
 from yazot.crossref_client import CrossrefClient, CrossrefWork
 from yazot.exceptions import DOINotFoundError, InvalidDOIError
-from yazot.mcp_server import mcp
 from yazot.models import ItemCreate
 from yazot.zotero_client import ZoteroClient
 
@@ -116,17 +115,17 @@ class TestAddItemByDOI:
         self,
         test_data_manager: ZoteroTestDataManager,
         test_zotero_client: ZoteroClient,
+        mcp_client: Client,
     ) -> None:
         """Test adding an item using a valid DOI."""
         # Using a well-known, stable DOI
         doi = "10.1038/nature12373"
 
-        async with Client(mcp) as client:
-            result = await client.call_tool(
-                "add_item_by_doi",
-                arguments={"doi": doi},
-            )
-            item = result.data
+        result = await mcp_client.call_tool(
+            "add_item_by_doi",
+            arguments={"doi": doi},
+        )
+        item = result.data
 
         # Verify item was created
         assert item is not None
@@ -143,17 +142,17 @@ class TestAddItemByDOI:
         self,
         test_data_manager: ZoteroTestDataManager,
         test_zotero_client: ZoteroClient,
+        mcp_client: Client,
     ) -> None:
         """Test adding an item with tags."""
         doi = "10.1038/nature12373"
         tags = ["important", "to-read", "genetics"]
 
-        async with Client(mcp) as client:
-            result = await client.call_tool(
-                "add_item_by_doi",
-                arguments={"doi": doi, "tags": tags},
-            )
-            item = result.data
+        result = await mcp_client.call_tool(
+            "add_item_by_doi",
+            arguments={"doi": doi, "tags": tags},
+        )
+        item = result.data
 
         # Verify item was created with tags
         assert item is not None
@@ -170,27 +169,26 @@ class TestAddItemByDOI:
         self,
         test_data_manager: ZoteroTestDataManager,
         test_zotero_client: ZoteroClient,
+        mcp_client: Client,
     ) -> None:
         """Test adding an item to a specific collection."""
         # First create a test collection
-        async with Client(mcp) as client:
-            coll_result = await client.call_tool(
-                "create_collection",
-                arguments={"name": "Test DOI Collection"},
-            )
-            collection_data = coll_result.data
+        coll_result = await mcp_client.call_tool(
+            "create_collection",
+            arguments={"name": "Test DOI Collection"},
+        )
+        collection_data = coll_result.data
 
         # Add item to collection
         doi = "10.1038/nature12373"
-        async with Client(mcp) as client:
-            item_result = await client.call_tool(
-                "add_item_by_doi",
-                arguments={
-                    "doi": doi,
-                    "collection_key": collection_data["key"],
-                },
-            )
-            item = item_result.data
+        item_result = await mcp_client.call_tool(
+            "add_item_by_doi",
+            arguments={
+                "doi": doi,
+                "collection_key": collection_data["key"],
+            },
+        )
+        item = item_result.data
 
         # Verify item was added to collection
         assert item is not None
@@ -205,16 +203,16 @@ class TestAddItemByDOI:
         self,
         test_data_manager: ZoteroTestDataManager,
         test_zotero_client: ZoteroClient,
+        mcp_client: Client,
     ) -> None:
         """Test that DOI URLs are properly handled."""
         doi_url = "https://doi.org/10.1038/nature12373"
 
-        async with Client(mcp) as client:
-            result = await client.call_tool(
-                "add_item_by_doi",
-                arguments={"doi": doi_url},
-            )
-            item = result.data
+        result = await mcp_client.call_tool(
+            "add_item_by_doi",
+            arguments={"doi": doi_url},
+        )
+        item = result.data
 
         # Verify item was created with clean DOI
         assert item is not None
@@ -228,13 +226,13 @@ class TestAddItemByDOI:
         self,
         test_data_manager: ZoteroTestDataManager,
         test_zotero_client: ZoteroClient,
+        mcp_client: Client,
     ) -> None:
         """Test that invalid DOI raises appropriate error."""
         invalid_doi = "not-a-valid-doi"
 
-        async with Client(mcp) as client:
-            with pytest.raises(ToolError, match="DOI must start with"):
-                await client.call_tool(
-                    "add_item_by_doi",
-                    arguments={"doi": invalid_doi},
-                )
+        with pytest.raises(ToolError, match="DOI must start with"):
+            await mcp_client.call_tool(
+                "add_item_by_doi",
+                arguments={"doi": invalid_doi},
+            )


### PR DESCRIPTION
FastMCP 2.x never resets _lifespan_result_set after Client disconnects (cleanup code in _lifespan_manager is unreachable due to anyio task group cancellation). Subsequent Client(mcp) sessions reuse stale lifespan context with closed httpx clients.

- Add autouse _reset_mcp_lifespan fixture (WORKAROUND)
- Add mcp_client fixture for per-test Client sessions
- Migrate test_doi.py to use mcp_client fixture

## Summary by Sourcery

Work around a FastMCP lifespan cleanup bug by resetting the MCP lifespan between tests and updating DOI-related tests to use a shared per-test MCP client fixture.

Bug Fixes:
- Prevent reuse of stale FastMCP lifespan context with closed resources across tests.

Enhancements:
- Introduce an autouse fixture to reset FastMCP lifespan state before each test.
- Add a reusable per-test MCP client fixture and migrate DOI tests to use it.