### PR TITLE
chore: add Claude Code hooks and worktree workflow

### DIFF
--- a/.claude/hooks/format-python.sh
+++ b/.claude/hooks/format-python.sh
@@ -5,5 +5,4 @@ FILE="$TOOL_INPUT_FILE_PATH"
 
 [[ "$FILE" == *.py ]] || exit 0
 
-uv run ruff check --fix --quiet "$FILE" 2>/dev/null
-uv run black --quiet "$FILE" 2>/dev/null
+uv run bash -c 'ruff check --fix --quiet "$1" 2>/dev/null; black --quiet "$1" 2>/dev/null' _ "$FILE"

--- a/.claude/hooks/format-python.sh
+++ b/.claude/hooks/format-python.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# PostToolUse hook: auto-format Python files after Edit/Write.
+
+FILE="$TOOL_INPUT_FILE_PATH"
+
+[[ "$FILE" == *.py ]] || exit 0
+
+uv run ruff check --fix --quiet "$FILE" 2>/dev/null
+uv run black --quiet "$FILE" 2>/dev/null

--- a/.claude/hooks/pr-monitor.sh
+++ b/.claude/hooks/pr-monitor.sh
@@ -8,14 +8,14 @@ INPUT=$(cat)
 # Quick exit: not a gh pr create command
 echo "$INPUT" | grep -q "gh pr create" || exit 0
 
-# Exclude dry-run, help, and list commands
-echo "$INPUT" | grep -qE "(--help|--dry-run|gh pr create\b.*\blist)" && exit 0
+# Exclude dry-run and help commands
+echo "$INPUT" | grep -qE "(--help|--dry-run)" && exit 0
 
 # Extract PR URL from output
-PR_URL=$(echo "$INPUT" | grep -oP 'https://github\.com/[^"]+/pull/\d+' | head -1)
+PR_URL=$(echo "$INPUT" | grep -oE 'https://github\.com/[^"]+/pull/[0-9]+' | head -1)
 [ -z "$PR_URL" ] && exit 0
 
-PR_NUM=$(echo "$PR_URL" | grep -oP '\d+$')
+PR_NUM=$(echo "$PR_URL" | grep -oE '[0-9]+$')
 REPORT="/tmp/pr-${PR_NUM}-report.md"
 HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
 

--- a/.claude/hooks/pr-monitor.sh
+++ b/.claude/hooks/pr-monitor.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# PostToolUse hook: detect `gh pr create`, start background monitoring,
+# and force Claude to acknowledge via exit 2.
+# Fires on every Bash call but exits immediately if not PR creation.
+
+INPUT=$(cat)
+
+# Quick exit: not a gh pr create command
+echo "$INPUT" | grep -q "gh pr create" || exit 0
+
+# Exclude dry-run, help, and list commands
+echo "$INPUT" | grep -qE "(--help|--dry-run|gh pr create\b.*\blist)" && exit 0
+
+# Extract PR URL from output
+PR_URL=$(echo "$INPUT" | grep -oP 'https://github\.com/[^"]+/pull/\d+' | head -1)
+[ -z "$PR_URL" ] && exit 0
+
+PR_NUM=$(echo "$PR_URL" | grep -oP '\d+$')
+REPORT="/tmp/pr-${PR_NUM}-report.md"
+HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Start background monitoring (self-contained, no Claude needed)
+nohup "$HOOK_DIR/pr-watch.sh" "$PR_NUM" 12 300 > /dev/null 2>&1 &
+
+# Inform Claude about the PR and report location
+cat >&2 <<EOF
+PR_CREATED: PR #${PR_NUM} (${PR_URL}).
+Background CI monitor started (PID $!, polling every 5 min, max 1 hour).
+Report: ${REPORT}
+When the user asks about PR status, read ${REPORT}.
+EOF
+
+exit 2

--- a/.claude/hooks/pr-watch.sh
+++ b/.claude/hooks/pr-watch.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# Background PR monitor — polls GitHub CI checks and writes report.
+# Usage: pr-watch.sh <PR_NUMBER> [max_iterations] [interval_seconds]
+#
+# Spawned by pr-monitor.sh PostToolUse hook. Runs detached from Claude session.
+# Writes final report to /tmp/pr-<N>-report.md when all checks complete.
+
+set -euo pipefail
+
+PR_NUM="${1:?Usage: pr-watch.sh <PR_NUMBER>}"
+MAX_ITER="${2:-12}"
+INTERVAL="${3:-300}"
+REPORT="/tmp/pr-${PR_NUM}-report.md"
+
+# Write initial status
+echo "# PR #${PR_NUM} — Monitoring started $(date -Iseconds)" > "$REPORT"
+echo "Checking every ${INTERVAL}s, max ${MAX_ITER} iterations." >> "$REPORT"
+
+for ((i=1; i<=MAX_ITER; i++)); do
+    sleep "$INTERVAL"
+
+    # Get check statuses
+    CHECKS=$(gh pr checks "$PR_NUM" 2>&1) || true
+    STATUS_JSON=$(gh pr view "$PR_NUM" --json statusCheckRollup,comments,reviews,state 2>&1) || true
+
+    # Count pending checks
+    PENDING=$(echo "$CHECKS" | grep -c "pending\|queued\|in_progress" || true)
+
+    if [ "$PENDING" -eq 0 ]; then
+        # All done — write final report
+        cat > "$REPORT" <<REPORT_EOF
+# PR #${PR_NUM} — CI Complete ($(date -Iseconds))
+
+## Check Results
+\`\`\`
+${CHECKS}
+\`\`\`
+
+## Reviews & Comments
+\`\`\`json
+${STATUS_JSON}
+\`\`\`
+REPORT_EOF
+        exit 0
+    fi
+
+    # Still pending — update status
+    echo "Iteration ${i}/${MAX_ITER}: ${PENDING} checks pending ($(date -Iseconds))" >> "$REPORT"
+done
+
+# Timeout — write what we have
+cat > "$REPORT" <<REPORT_EOF
+# PR #${PR_NUM} — Monitoring Timeout ($(date -Iseconds))
+
+Gave up after ${MAX_ITER} iterations ($(( MAX_ITER * INTERVAL / 60 )) minutes).
+
+## Last Check Results
+\`\`\`
+${CHECKS:-no data}
+\`\`\`
+
+## Reviews & Comments
+\`\`\`json
+${STATUS_JSON:-no data}
+\`\`\`
+REPORT_EOF

--- a/.claude/hooks/require-worktree-agent.sh
+++ b/.claude/hooks/require-worktree-agent.sh
@@ -5,13 +5,15 @@
 git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
 
 BRANCH=$(git branch --show-current 2>/dev/null)
-[ "$BRANCH" != "main" ] && [ "$BRANCH" != "master" ] && exit 0
+DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||')
+DEFAULT_BRANCH="${DEFAULT_BRANCH:-main}"
+[ "$BRANCH" != "$DEFAULT_BRANCH" ] && exit 0
 
 # Read tool input from stdin
 INPUT=$(cat)
 
-# Extract subagent_type (grep -oP: Perl regex, \K resets match start)
-SUBAGENT=$(echo "$INPUT" | grep -oP '"subagent_type"\s*:\s*"\K[^"]*' || true)
+# Extract subagent_type
+SUBAGENT=$(echo "$INPUT" | sed -n 's/.*"subagent_type"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
 
 # Block development agents on main (Explore is read-only — allowed)
 case "$SUBAGENT" in

--- a/.claude/hooks/require-worktree-agent.sh
+++ b/.claude/hooks/require-worktree-agent.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# PreToolUse hook for Agent: блокирует аналитических и девелоперских агентов на main.
+# Заставляет войти в worktree перед запуском, чтобы анализ и правки были в одном контексте.
+
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
+
+BRANCH=$(git branch --show-current 2>/dev/null)
+[ "$BRANCH" != "main" ] && [ "$BRANCH" != "master" ] && exit 0
+
+# Read tool input from stdin
+INPUT=$(cat)
+
+# Extract subagent_type (grep -oP: Perl regex, \K resets match start)
+SUBAGENT=$(echo "$INPUT" | grep -oP '"subagent_type"\s*:\s*"\K[^"]*' || true)
+
+# Block development agents on main (Explore is read-only — allowed)
+case "$SUBAGENT" in
+  Plan|python-developer|feature-dev:*)
+    cat >&2 <<'EOF'
+BLOCKED: Аналитический/архитектурный агент на ветке main.
+Войди в worktree через EnterWorktree перед запуском анализа или разработки.
+Это обеспечит, что анализ и последующие изменения будут в одном worktree.
+EOF
+    exit 2
+    ;;
+esac
+
+exit 0

--- a/.claude/hooks/require-worktree.sh
+++ b/.claude/hooks/require-worktree.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# PreToolUse hook: блокирует Edit/Write на ветке main.
+# Для любых изменений нужен worktree или feature-ветка.
+
+# Проверяем, что мы в git-репозитории
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
+
+# Пропускаем файлы вне репозитория (plan-файлы, глобальный .claude/ и т.д.)
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | grep -oP '"file_path"\s*:\s*"\K[^"]*' || true)
+if [ -n "$FILE_PATH" ]; then
+  REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+  case "$FILE_PATH" in
+    "$REPO_ROOT"/*) ;; # файл в репо — проверяем дальше
+    *) exit 0 ;;       # файл вне репо — пропускаем
+  esac
+fi
+
+BRANCH=$(git branch --show-current 2>/dev/null)
+
+if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "master" ]; then
+  cat >&2 <<'EOF'
+BLOCKED: Редактирование файлов на ветке main запрещено.
+Войди в worktree через EnterWorktree перед внесением изменений.
+EOF
+  exit 2
+fi
+
+exit 0

--- a/.claude/hooks/require-worktree.sh
+++ b/.claude/hooks/require-worktree.sh
@@ -7,7 +7,7 @@ git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
 
 # Пропускаем файлы вне репозитория (plan-файлы, глобальный .claude/ и т.д.)
 INPUT=$(cat)
-FILE_PATH=$(echo "$INPUT" | grep -oP '"file_path"\s*:\s*"\K[^"]*' || true)
+FILE_PATH=$(echo "$INPUT" | sed -n 's/.*"file_path"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
 if [ -n "$FILE_PATH" ]; then
   REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
   case "$FILE_PATH" in
@@ -17,8 +17,10 @@ if [ -n "$FILE_PATH" ]; then
 fi
 
 BRANCH=$(git branch --show-current 2>/dev/null)
+DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||')
+DEFAULT_BRANCH="${DEFAULT_BRANCH:-main}"
 
-if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "master" ]; then
+if [ "$BRANCH" = "$DEFAULT_BRANCH" ]; then
   cat >&2 <<'EOF'
 BLOCKED: Редактирование файлов на ветке main запрещено.
 Войди в worktree через EnterWorktree перед внесением изменений.

--- a/.claude/hooks/worktree-setup.sh
+++ b/.claude/hooks/worktree-setup.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# WorktreeCreate hook: symlink .env files from main repo + install dev dependencies.
+
+ROOT=$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")
+
+for f in .env .env.test; do
+  [ -f "$ROOT/$f" ] && [ ! -e "$f" ] && ln -s "$ROOT/$f" "$f"
+done
+
+uv sync --group dev

--- a/.claude/hooks/worktree-stop.sh
+++ b/.claude/hooks/worktree-stop.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Stop hook: блокирует завершение сессии в worktree,
+# чтобы Claude спросил пользователя о судьбе изменений.
+
+INPUT=$(cat)
+
+# Предотвращаем бесконечный цикл — на повторной попытке пропускаем
+if echo "$INPUT" | grep -qE '"stop_hook_active"\s*:\s*true'; then
+  exit 0
+fi
+
+# Проверяем, что мы в git-репозитории
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
+
+# Проверяем, что это worktree (не основной репо)
+GIT_DIR=$(git rev-parse --git-dir 2>/dev/null)
+GIT_COMMON_DIR=$(git rev-parse --git-common-dir 2>/dev/null)
+if [ "$GIT_DIR" = "$GIT_COMMON_DIR" ]; then
+  exit 0
+fi
+
+# Собираем информацию о состоянии
+BRANCH=$(git branch --show-current 2>/dev/null)
+HAS_CHANGES=$(git status --porcelain 2>/dev/null | head -1)
+AHEAD=$(git rev-list main..HEAD --count 2>/dev/null || echo "0")
+
+# Блокируем stop — stderr покажется Claude
+cat >&2 <<EOF
+WORKTREE_PENDING: Сессия в worktree, ветка '$BRANCH'.
+Коммитов впереди main: $AHEAD
+Незакоммиченные изменения: $([ -n "$HAS_CHANGES" ] && echo "есть" || echo "нет")
+
+Перед завершением спроси пользователя:
+1) Push ветки + создать PR в main + удалить worktree
+2) Оставить worktree (для продолжения позже)
+3) Отменить изменения + удалить worktree
+EOF
+
+exit 2

--- a/.claude/hooks/worktree-stop.sh
+++ b/.claude/hooks/worktree-stop.sh
@@ -22,7 +22,9 @@ fi
 # Собираем информацию о состоянии
 BRANCH=$(git branch --show-current 2>/dev/null)
 HAS_CHANGES=$(git status --porcelain 2>/dev/null | head -1)
-AHEAD=$(git rev-list main..HEAD --count 2>/dev/null || echo "0")
+DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||')
+DEFAULT_BRANCH="${DEFAULT_BRANCH:-main}"
+AHEAD=$(git rev-list "$DEFAULT_BRANCH"..HEAD --count 2>/dev/null || echo "0")
 
 # Блокируем stop — stderr покажется Claude
 cat >&2 <<EOF

--- a/.claude/hooks/worktree-venv.sh
+++ b/.claude/hooks/worktree-venv.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Ensure worktree has no stale .venv symlink (uv run will create .venv on first use)
+
+GIT_DIR=$(git rev-parse --git-dir 2>/dev/null) || exit 0
+GIT_COMMON_DIR=$(git rev-parse --git-common-dir 2>/dev/null) || exit 0
+
+# Only act in worktrees
+[ "$GIT_DIR" = "$GIT_COMMON_DIR" ] && exit 0
+
+# Real .venv already exists — skip
+[ -d ".venv" ] && [ -f ".venv/pyvenv.cfg" ] && exit 0
+
+# Remove stale symlink
+[ -L ".venv" ] && rm -f .venv

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/format-python.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,8 +75,8 @@ pre-commit run --all-files
 
 - Feature development: always enter a worktree via `EnterWorktree` before making changes
 - Quick fixes, typos, config changes — work directly in main, no worktree needed
-- To resume work in an existing worktree — use `EnterWorktree` with the same name. Never `cd` into worktree path directly
-- Worktrees contain only git-tracked files. `hooks/`, `settings.json`, `settings.local.json` live in `$CLAUDE_PROJECT_DIR/.claude/` and are shared — edit them by the main project path
+- To resume work in an existing worktree — use `EnterWorktree` with the same name. Never `cd` into the worktree path directly
+- Worktrees contain only git-tracked files. `hooks/`, `settings.json`, `settings.local.json` live in `$CLAUDE_PROJECT_DIR/.claude/` and are shared — edit them from the main project path
 - `ExitWorktree(remove)` requires `discard_changes=true` if there are commits not in main (even if already pushed)
 - The Stop hook blocks session end in a worktree — ask the user to choose:
   1. **Push + PR**: commit all, `git push -u origin <branch>`, `gh pr create`, then `ExitWorktree(remove, discard_changes=true)`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,18 @@ pre-commit run --all-files
 
 **Claude Code hooks**: PostToolUse on Edit/Write auto-runs ruff --fix + black on .py files.
 
+## Worktree Workflow
+
+- Feature development: always enter a worktree via `EnterWorktree` before making changes
+- Quick fixes, typos, config changes — work directly in main, no worktree needed
+- To resume work in an existing worktree — use `EnterWorktree` with the same name. Never `cd` into worktree path directly
+- Worktrees contain only git-tracked files. `hooks/`, `settings.json`, `settings.local.json` live in `$CLAUDE_PROJECT_DIR/.claude/` and are shared — edit them by the main project path
+- `ExitWorktree(remove)` requires `discard_changes=true` if there are commits not in main (even if already pushed)
+- The Stop hook blocks session end in a worktree — ask the user to choose:
+  1. **Push + PR**: commit all, `git push -u origin <branch>`, `gh pr create`, then `ExitWorktree(remove, discard_changes=true)`
+  2. **Keep**: `ExitWorktree(keep)` — worktree stays for later
+  3. **Discard**: `ExitWorktree(remove, discard_changes=true)`
+
 ## Environment
 
 Configuration via `.env` (pydantic-settings). Two modes:


### PR DESCRIPTION
- Hook scripts for worktree enforcement, auto-formatting, and PR monitoring
- Shared `settings.json` has only `format-python` hook; personal workflow hooks go in `settings.local.json` (gitignored)
- CLAUDE.md documents worktree workflow conventions

## Summary by Sourcery

Introduce Claude Code worktree-based workflow conventions and automation hooks for safer development on non-main branches and automated PR monitoring.

Enhancements:
- Add shell hooks to enforce using git worktrees for edits and agent runs instead of working directly on main, including environment setup and venv maintenance for worktrees.
- Introduce PostToolUse hooks to auto-format Python files after edits using Ruff and Black.
- Add hooks to detect PR creation via `gh pr create`, spawn a background CI monitor, and surface PR/CI status to Claude sessions.

Documentation:
- Document the recommended worktree-based development workflow and Claude Code integration in CLAUDE.md, including conventions for entering, exiting, and managing worktrees.