### PR TITLE
Add progress reporting to long-running MCP tools

### DIFF
--- a/yazot/mcp_server.py
+++ b/yazot/mcp_server.py
@@ -207,6 +207,8 @@ async def get_collection_items(
         if not subcollections:
             return items
 
+        await ctx.info(f"Traversing {len(subcollections)} subcollections")
+
         results = await asyncio.gather(
             *(collect_items_recursive(sub) for sub in subcollections),
             return_exceptions=True,
@@ -554,6 +556,7 @@ async def get_item_fulltext(item_key: str, ctx: Context) -> FulltextResponse:
     fulltext = await router.get_fulltext(item_key)
 
     if not fulltext:
+        await ctx.info("Indexed fulltext not available, extracting from PDF")
         fulltext = await router.get_pdf_text(item_key)
 
     if not fulltext:
@@ -654,6 +657,7 @@ async def verify_note(note_key: str, ctx: Context) -> VerificationResult:
         2. Verify the quotes: verify_note(note_key)
     """
     verifier: NoteVerifier = _deps(ctx)["verifier"]
+    await ctx.info("Verifying quotes against article fulltext")
     return await verifier.verify(note_key)
 
 
@@ -714,11 +718,16 @@ async def fetch_external_fulltext(
         raise ZoteroError("At least one of doi or title must be provided or resolvable from item")
 
     # Resolve PDF URL through cascade
+    await ctx.report_progress(progress=0, total=3)
     pdf_url, source = await resolver.resolve(effective_doi, effective_title)
 
     # Download and extract text
+    await ctx.report_progress(progress=1, total=3)
     pdf_bytes = await resolver.download(pdf_url)
+
+    await ctx.report_progress(progress=2, total=3)
     text = resolver.extract_text(pdf_bytes)
+    await ctx.report_progress(progress=3, total=3)
 
     if not text.strip():
         return ExternalFulltextResponse(


### PR DESCRIPTION
- `fetch_external_fulltext`: `report_progress(0..3/3)` across resolve → download → extract pipeline
- `get_collection_items`, `get_item_fulltext`, `verify_note`: `ctx.info()` messages for status updates
- Fire-and-forget, no logic changes — existing tests pass as-is

## Summary by Sourcery

Add user-visible progress and status reporting for long-running MCP tools to improve transparency during execution.

New Features:
- Report stepwise progress for external fulltext fetching across resolve, download, and extract stages.

Enhancements:
- Emit contextual status messages while traversing collections, extracting item fulltext from PDFs, and verifying note quotes against article fulltext.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added detailed logging and progress reporting for collection traversal operations.
  * Enhanced progress tracking for PDF text extraction workflows with discrete status updates (resolution, download, extraction, and completion).
  * Improved logging visibility for fulltext indexing and quote verification operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->