### PR TITLE
Flatten search_articles MCP tool parameters

### DIFF
--- a/tests/e2e/test_search.py
+++ b/tests/e2e/test_search.py
@@ -141,7 +141,7 @@ class TestSearchE2E:
         """Test that search_articles responses stay under MCP 25000 token limit."""
         collection_key, _ = basic_collection_with_items
 
-        request = {"search_params": {}, "collection_key": collection_key}
+        request = {"collection_key": collection_key}
 
         async with Client(mcp) as client:
             result = await client.call_tool("search_articles", arguments=request)
@@ -239,7 +239,7 @@ class TestSearchE2E:
         test_zotero_client: ZoteroClient,
     ) -> None:
         """Test search_articles without collection_key searches entire library."""
-        request = {"search_params": {"q": "test"}}
+        request = {"query": "test"}
 
         async with Client(mcp) as client:
             result = await client.call_tool("search_articles", arguments=request)
@@ -256,7 +256,7 @@ class TestSearchE2E:
         test_zotero_client: ZoteroClient,
     ) -> None:
         """Test search_articles with item_type filter."""
-        request = {"search_params": {"item_type": "journalArticle"}}
+        request = {"item_type": "journalArticle"}
 
         async with Client(mcp) as client:
             result = await client.call_tool("search_articles", arguments=request)
@@ -272,7 +272,7 @@ class TestSearchE2E:
         test_zotero_client: ZoteroClient,
     ) -> None:
         """Test search_articles with multiple search parameters combined."""
-        request = {"search_params": {"q": "learning", "item_type": "journalArticle"}}
+        request = {"query": "learning", "item_type": "journalArticle"}
 
         async with Client(mcp) as client:
             result = await client.call_tool("search_articles", arguments=request)

--- a/tests/e2e/test_tags.py
+++ b/tests/e2e/test_tags.py
@@ -60,7 +60,7 @@ class TestTagsE2E:
 
         async with Client(mcp) as client:
             result = await client.call_tool(
-                "search_articles", arguments={"search_params": {"tag": [search_tag]}}
+                "search_articles", arguments={"tags": [search_tag]}
             )
             response = result.data
 
@@ -85,7 +85,7 @@ class TestTagsE2E:
 
         async with Client(mcp) as client:
             result = await client.call_tool(
-                "search_articles", arguments={"search_params": {"tag": search_tags}}
+                "search_articles", arguments={"tags": search_tags}
             )
             response = result.data
 

--- a/tests/e2e/test_web_api.py
+++ b/tests/e2e/test_web_api.py
@@ -39,7 +39,7 @@ class TestWebApiWrite:
         async with Client(mcp) as client:
             result = await client.call_tool(
                 "search_articles",
-                arguments={"search_params": {"q": title_fragment}},
+                arguments={"query": title_fragment},
             )
             response = result.data
 
@@ -187,7 +187,7 @@ class TestWebApiWrite:
         async with Client(mcp) as client:
             result = await client.call_tool(
                 "search_articles",
-                arguments={"search_params": {"item_type": "journalArticle"}},
+                arguments={"item_type": "journalArticle"},
             )
             response = result.data
 
@@ -312,7 +312,7 @@ class TestDoiSearchAndCreate:
             async with Client(mcp) as client:
                 search_result = await client.call_tool(
                     "search_articles",
-                    arguments={"search_params": {"q": "Nanometre-scale thermometry"}},
+                    arguments={"query": "Nanometre-scale thermometry"},
                 )
                 response = search_result.data
 

--- a/tests/live/test_local_instance.py
+++ b/tests/live/test_local_instance.py
@@ -97,7 +97,7 @@ class TestLocalInstanceRead:
         monkeypatch.setenv("ZOTERO_API_KEY", "")
 
         async with Client(mcp) as client:
-            result = await client.call_tool("search_articles", arguments={"search_params": {}})
+            result = await client.call_tool("search_articles", arguments={})
             response = result.data
 
         assert isinstance(response.items, list)

--- a/yazot/mcp_server.py
+++ b/yazot/mcp_server.py
@@ -277,23 +277,16 @@ async def get_next_chunk(chunk_id: str, ctx: Context) -> SearchCollectionRespons
 
 @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True, idempotentHint=True))
 async def search_articles(
-    search_params: ZoteroSearchParams,
     ctx: Context,
+    query: str | None = None,
+    tags: list[str] | None = None,
     collection_key: str | None = None,
+    item_type: str | None = None,
 ) -> SearchCollectionResponse:
     """
     Search for articles by name, tags, collections, or item type.
 
     Supports flexible searching across your Zotero library with multiple filter options.
-
-    Args:
-        query: Quick search string to match against titles and creators (optional)
-        tags: List of tags to filter by - items must have ALL listed tags (optional)
-        collection_key: Filter by specific collection key (optional)
-        item_type: Filter by item type (e.g., 'journalArticle', 'book', 'conferencePaper') (optional)
-
-    Returns:
-        SearchCollectionResponse with matching items
 
     Note:
         To get full text content for an item, use the separate 'get_item_fulltext' tool.
@@ -318,6 +311,7 @@ async def search_articles(
         # Combine filters
         search_articles(query="neural networks", tags=["AI"], item_type="journalArticle")
     """
+    search_params = ZoteroSearchParams(q=query, tag=tags, item_type=item_type)
     router: ZoteroClientRouter = _deps(ctx)["router"]
     chunker: ResponseChunker = _deps(ctx)["chunker"]
 


### PR DESCRIPTION
## Summary

- LLMs frequently fail to construct nested `search_params: {q, tag, item_type}` JSON — flatten to top-level `query`, `tags`, `collection_key`, `item_type` parameters
- `ZoteroSearchParams` model and internal layers unchanged — only the MCP tool signature is affected
- Docstring and `TOOL_INSTRUCTIONS` already described flat params, now the implementation matches

## Summary by Sourcery

Flatten the MCP search_articles tool interface to accept top-level query, tags, collection_key, and item_type parameters while preserving internal search handling.

New Features:
- Expose flat query, tags, collection_key, and item_type arguments on the search_articles MCP tool instead of a nested search_params object.

Tests:
- Update e2e and live tests to call the search_articles tool using the new flat parameter shape and verify behavior remains unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified the search tool API by flattening parameter structure. Search parameters are now passed directly as individual fields (query, tags, collection_key, item_type) instead of a nested object, resulting in a cleaner and more intuitive interface for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->