### PR TITLE
refactor: replace everything() with offset-based pagination

### DIFF
--- a/.claude/rules/concurrency.md
+++ b/.claude/rules/concurrency.md
@@ -3,8 +3,9 @@ globs: ["yazot/**/*.py"]
 ---
 # Concurrency patterns
 
-- `ZoteroClient._call` and `Collection._call` wrap all pyzotero calls with an optional `asyncio.Semaphore`
+- **Non-paginated calls**: `ZoteroClient._call` and `Collection._call` wrap pyzotero calls with semaphore + `asyncio.to_thread` using a shared client
+- **Paginated calls**: `_fetch_all_paginated()` uses an isolated pyzotero client (via `_make_client()`) and acquires the semaphore per page, not per pagination sequence. This avoids thread pool exhaustion and shared mutable state (`self.links`, `self.url_params`) races
 - Semaphore is created in `ZoteroClient.__init__` only for web mode (`Settings.web_zotero_max_concurrent_requests`)
 - Local mode: semaphore is `None`, no rate limiting
-- All `Collection` instances receive the semaphore from `ZoteroClient` — rate limit is global per client
-- When adding new parallel operations: do NOT create local semaphores — rely on the client-level one in `_call`
+- All `Collection` instances receive the semaphore and `_make_client` factory from `ZoteroClient` — rate limit is global per client
+- When adding new parallel operations: do NOT create local semaphores — use `_fetch_all_paginated()` for paginated calls, `_call()` for single calls

--- a/tests/unit/test_pagination.py
+++ b/tests/unit/test_pagination.py
@@ -1,0 +1,139 @@
+"""Tests for offset-based pagination (_fetch_all_paginated)."""
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+from yazot.zotero_client import _ZOTERO_PAGE_LIMIT, _fetch_all_paginated
+
+
+def _make_mock_client(pages: list[list[dict]]) -> MagicMock:
+    """Create a mock pyzotero client that returns pages sequentially."""
+    client = MagicMock()
+    call_count = 0
+
+    def top_side_effect(*args, **kwargs):
+        nonlocal call_count
+        page = pages[call_count] if call_count < len(pages) else []
+        call_count += 1
+        return page
+
+    client.top = MagicMock(side_effect=top_side_effect)
+    client.collections = MagicMock(side_effect=top_side_effect)
+    client.collection_items_top = MagicMock(side_effect=top_side_effect)
+    return client
+
+
+@pytest.fixture
+def items_page() -> list[dict]:
+    """A full page of 100 items."""
+    return [{"key": f"ITEM{i:04d}", "data": {}} for i in range(_ZOTERO_PAGE_LIMIT)]
+
+
+@pytest.fixture
+def partial_page() -> list[dict]:
+    """A partial page (< 100 items) signaling end of pagination."""
+    return [{"key": f"LAST{i:02d}", "data": {}} for i in range(30)]
+
+
+async def test_single_page_no_pagination(partial_page):
+    """Single page with fewer items than limit — no further requests."""
+    client = _make_mock_client([partial_page])
+    result = await _fetch_all_paginated(client, "top", None)
+    assert len(result) == 30
+    assert client.top.call_count == 1
+    _, kwargs = client.top.call_args
+    assert kwargs["limit"] == _ZOTERO_PAGE_LIMIT
+    assert kwargs["start"] == 0
+
+
+async def test_multi_page_pagination(items_page, partial_page):
+    """Multiple full pages followed by a partial page."""
+    client = _make_mock_client([items_page, items_page, partial_page])
+    result = await _fetch_all_paginated(client, "top", None)
+    assert len(result) == _ZOTERO_PAGE_LIMIT * 2 + 30
+    assert client.top.call_count == 3
+    # Verify start offsets
+    starts = [call.kwargs["start"] for call in client.top.call_args_list]
+    assert starts == [0, _ZOTERO_PAGE_LIMIT, _ZOTERO_PAGE_LIMIT * 2]
+
+
+async def test_empty_result():
+    """Empty library returns empty list without errors."""
+    client = _make_mock_client([[]])
+    result = await _fetch_all_paginated(client, "top", None)
+    assert result == []
+    assert client.top.call_count == 1
+
+
+async def test_exactly_one_full_page(items_page):
+    """Exactly one full page — must fetch a second (empty) page to confirm end."""
+    client = _make_mock_client([items_page, []])
+    result = await _fetch_all_paginated(client, "top", None)
+    assert len(result) == _ZOTERO_PAGE_LIMIT
+    assert client.top.call_count == 2
+
+
+async def test_api_params_forwarded(partial_page):
+    """Extra api_params (e.g. search query) are forwarded to every page request."""
+    client = _make_mock_client([partial_page])
+    await _fetch_all_paginated(client, "top", None, q="test query", qmode="everything")
+    _, kwargs = client.top.call_args
+    assert kwargs["q"] == "test query"
+    assert kwargs["qmode"] == "everything"
+    assert kwargs["limit"] == _ZOTERO_PAGE_LIMIT
+
+
+async def test_api_params_limit_overridden(partial_page):
+    """User-supplied limit is overridden by _ZOTERO_PAGE_LIMIT."""
+    client = _make_mock_client([partial_page])
+    await _fetch_all_paginated(client, "top", None, limit=25)
+    _, kwargs = client.top.call_args
+    assert kwargs["limit"] == _ZOTERO_PAGE_LIMIT
+
+
+async def test_collection_items_top_with_positional_arg(partial_page):
+    """Positional args (e.g. collection key) are passed through."""
+    client = _make_mock_client([partial_page])
+    await _fetch_all_paginated(client, "collection_items_top", None, "COL_KEY")
+    args, kwargs = client.collection_items_top.call_args
+    assert args == ("COL_KEY",)
+    assert kwargs["limit"] == _ZOTERO_PAGE_LIMIT
+
+
+async def test_semaphore_limits_concurrent_requests(items_page, partial_page):
+    """Semaphore limits concurrent HTTP requests across interleaved paginations."""
+    semaphore = asyncio.Semaphore(2)
+    max_concurrent = 0
+    current_concurrent = 0
+
+    def tracking_top(*args, **kwargs):
+        nonlocal max_concurrent, current_concurrent
+        current_concurrent += 1
+        max_concurrent = max(max_concurrent, current_concurrent)
+        # Simulate pages: first call returns full page, second returns partial
+        start = kwargs.get("start", 0)
+        result = items_page if start == 0 else partial_page
+        current_concurrent -= 1
+        return result
+
+    client1 = MagicMock()
+    client1.top = MagicMock(side_effect=tracking_top)
+    client2 = MagicMock()
+    client2.top = MagicMock(side_effect=tracking_top)
+
+    # Run two paginations concurrently with shared semaphore
+    await asyncio.gather(
+        _fetch_all_paginated(client1, "top", semaphore),
+        _fetch_all_paginated(client2, "top", semaphore),
+    )
+    assert max_concurrent <= 2
+
+
+async def test_error_propagation():
+    """Errors from pyzotero are propagated without swallowing."""
+    client = MagicMock()
+    client.top = MagicMock(side_effect=RuntimeError("API error"))
+    with pytest.raises(RuntimeError, match="API error"):
+        await _fetch_all_paginated(client, "top", None)

--- a/yazot/zotero_client.py
+++ b/yazot/zotero_client.py
@@ -29,23 +29,62 @@ async def _run_sync[T](func: Callable[..., T], *args: Any, **kwargs: Any) -> T:
     return await asyncio.to_thread(func, *args, **kwargs)
 
 
+_ZOTERO_PAGE_LIMIT = 100  # Zotero API max items per request
+
+
+async def _fetch_all_paginated(
+    client: zotero.Zotero,
+    method_name: str,
+    semaphore: asyncio.Semaphore | None,
+    *args: Any,
+    **api_params: Any,
+) -> list[Any]:
+    """Fetch all items using offset-based pagination with per-page threading.
+
+    Each page is fetched in a separate thread via asyncio.to_thread(),
+    releasing the thread between pages. Uses an isolated pyzotero client
+    to avoid shared mutable state (self.links, self.url_params).
+
+    The semaphore limits concurrent HTTP requests to the Zotero API,
+    not entire pagination sequences.
+    """
+    method = getattr(client, method_name)
+    all_items: list[Any] = []
+    start = 0
+    while True:
+        page_params = {**api_params, "limit": _ZOTERO_PAGE_LIMIT, "start": start}
+        if semaphore is not None:
+            async with semaphore:
+                page = await asyncio.to_thread(method, *args, **page_params)
+        else:
+            page = await asyncio.to_thread(method, *args, **page_params)
+        all_items.extend(page)
+        if len(page) < _ZOTERO_PAGE_LIMIT:
+            break
+        start += _ZOTERO_PAGE_LIMIT
+    return all_items
+
+
 class Collection(ZoteroCollectionBase):
     """Represents a Zotero collection with async item access."""
 
     def __init__(
         self,
         client: zotero.Zotero,
+        client_factory: Callable[[], zotero.Zotero],
         data: dict[str, Any],
         semaphore: asyncio.Semaphore | None = None,
     ):
         """Initialize collection.
 
         Args:
-            client: Pyzotero client instance
+            client: Shared pyzotero client for non-paginated calls
+            client_factory: Factory to create isolated clients for paginated fetches
             data: Collection data from API
             semaphore: Optional semaphore to limit concurrent API requests
         """
         self._client = client
+        self._client_factory = client_factory
         self._semaphore = semaphore
         # Validate incoming data with Pydantic
         self._validated_data = ZoteroCollectionResponse.model_validate(data)
@@ -85,15 +124,18 @@ class Collection(ZoteroCollectionBase):
 
     async def get_items(self) -> list[ZoteroItem]:
         """Fetch all items in this collection."""
-        raw_items = await self._call(
-            lambda: self._client.everything(self._client.collection_items_top(self.key))
+        raw_items = await _fetch_all_paginated(
+            self._client_factory(), "collection_items_top", self._semaphore, self.key
         )
         return [ZoteroItem.model_validate(i) for i in raw_items]
 
     async def get_subcollections(self) -> list[ZoteroCollectionBase]:
         """Fetch subcollections of this collection."""
         subcoll_data = await self._call(self._client.collections_sub, self.key)
-        return [Collection(self._client, data, self._semaphore) for data in subcoll_data]
+        return [
+            Collection(self._client, self._client_factory, data, self._semaphore)
+            for data in subcoll_data
+        ]
 
     async def delete(self) -> None:
         """Delete this collection."""
@@ -124,6 +166,12 @@ class ZoteroClient(ZoteroClientProtocol):
             self._semaphore = asyncio.Semaphore(settings.web_zotero_max_concurrent_requests)
 
         self._cache: dict[str, Any] = {}  # Simple in-memory cache
+
+    def _make_client(self) -> zotero.Zotero:
+        """Create an isolated pyzotero client for paginated operations."""
+        if self._mode == "local":
+            return self._init_local_client()
+        return self._init_web_client()
 
     async def _call[T](self, func: Callable[..., T], *args: Any, **kwargs: Any) -> T:
         """Run sync function with optional semaphore rate limiting."""
@@ -177,7 +225,7 @@ class ZoteroClient(ZoteroClientProtocol):
     async def get_items(self) -> list[ZoteroItem]:
         """Fetch all top-level items in library (excludes attachments/notes)."""
         try:
-            raw_items = await self._call(lambda: self._client.everything(self._client.top()))
+            raw_items = await _fetch_all_paginated(self._make_client(), "top", self._semaphore)
             return [ZoteroItem.model_validate(i) for i in raw_items]
         except zotero_errors.UserNotAuthorisedError as e:
             raise ZoteroError(
@@ -198,10 +246,13 @@ class ZoteroClient(ZoteroClientProtocol):
     async def get_collections(self) -> list[ZoteroCollectionBase]:
         """Fetch all collections with pagination support."""
         try:
-            colls_data = await self._call(
-                lambda: self._client.everything(self._client.collections())
+            colls_data = await _fetch_all_paginated(
+                self._make_client(), "collections", self._semaphore
             )
-            return [Collection(self._client, data, self._semaphore) for data in colls_data]
+            return [
+                Collection(self._client, self._make_client, data, self._semaphore)
+                for data in colls_data
+            ]
         except zotero_errors.UserNotAuthorisedError as e:
             raise ZoteroError(
                 "Access denied when fetching collections. "
@@ -236,7 +287,7 @@ class ZoteroClient(ZoteroClientProtocol):
         if key is not None:
             try:
                 data = await self._call(self._client.collection, key)
-                return Collection(self._client, data, self._semaphore)
+                return Collection(self._client, self._make_client, data, self._semaphore)
             except zotero_errors.ResourceNotFoundError as e:
                 raise ZoteroNotFoundError("collection", key) from e
             except zotero_errors.PyZoteroError as e:
@@ -594,15 +645,11 @@ class ZoteroClient(ZoteroClientProtocol):
             ) from e
 
     async def search_items(self, search_params: ZoteroSearchParams) -> list[ZoteroItem]:
-        """Search top-level items across entire library with Zotero API parameters.
-
-        Uses pyzotero's top() method with search parameters, fetching all results
-        with automatic pagination via everything().
-        """
+        """Search top-level items across entire library with Zotero API parameters."""
         api_params = search_params.to_api_params()
         try:
-            raw_items = await self._call(
-                lambda: self._client.everything(self._client.top(**api_params))
+            raw_items = await _fetch_all_paginated(
+                self._make_client(), "top", self._semaphore, **api_params
             )
         except zotero_errors.UnsupportedParamsError as e:
             raise ZoteroError(
@@ -623,17 +670,15 @@ class ZoteroClient(ZoteroClientProtocol):
     async def search_collection_items(
         self, collection_key: str, search_params: ZoteroSearchParams
     ) -> list[ZoteroItem]:
-        """Search top-level items within a specific collection using Zotero API parameters.
-
-        Uses pyzotero's collection_items_top() with search parameters,
-        fetching all results with automatic pagination via everything().
-        """
+        """Search top-level items within a specific collection using Zotero API parameters."""
         api_params = search_params.to_api_params()
         try:
-            raw_items = await self._call(
-                lambda: self._client.everything(
-                    self._client.collection_items_top(collection_key, **api_params)
-                )
+            raw_items = await _fetch_all_paginated(
+                self._make_client(),
+                "collection_items_top",
+                self._semaphore,
+                collection_key,
+                **api_params,
             )
         except zotero_errors.ResourceNotFoundError as e:
             raise ZoteroNotFoundError("collection", collection_key) from e
@@ -691,7 +736,9 @@ class ZoteroClient(ZoteroClientProtocol):
                 ZoteroCollectionResponse.model_validate(coll) for coll in successful_colls
             ]
             return [
-                Collection(self._client, coll.model_dump(mode="json"), self._semaphore)
+                Collection(
+                    self._client, self._make_client, coll.model_dump(mode="json"), self._semaphore
+                )
                 for coll in validated_colls
             ]
         except ZoteroError:


### PR DESCRIPTION
## Summary
- pyzotero's `everything()` blocks a thread for the entire pagination sequence (dozens of HTTP requests). With concurrent MCP calls this exhausts the default thread pool
- Additionally, `everything()` mutates shared state (`self.links`, `self.url_params`) on the Zotero instance, causing race conditions when multiple paginations run in parallel threads
- Replaced all 5 `everything()` call sites with `_fetch_all_paginated()`: offset-based pagination with per-page `to_thread()` and isolated pyzotero client instances per operation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive pagination test coverage to validate data fetching and concurrency behavior.

* **Chores**
  * Refined pagination handling for retrieving items and collections.
  * Improved concurrency control during paginated data fetches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->