### PR TITLE
Add CI workflow for linting and testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
       - run: uv sync --group dev
       - run: uv run ruff check yazot/ tests/
       - run: uv run black --check yazot/ tests/
@@ -21,16 +24,22 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
       - run: uv sync --group dev
       - run: uv run pytest tests/unit/ -n auto -q
 
   e2e-tests:
     runs-on: ubuntu-latest
     needs: unit-tests
-    if: github.event_name == 'push' || !github.event.pull_request.head.repo.fork
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork)
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
       - run: uv sync --group dev
       - run: uv run pytest tests/e2e/ -q
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - run: uv sync --group dev
+      - run: uv run ruff check yazot/ tests/
+      - run: uv run black --check yazot/ tests/
+      - run: uv run mypy yazot/
+
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - run: uv sync --group dev
+      - run: uv run pytest tests/unit/ -n auto -q
+
+  e2e-tests:
+    runs-on: ubuntu-latest
+    needs: unit-tests
+    if: github.event_name == 'push' || !github.event.pull_request.head.repo.fork
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - run: uv sync --group dev
+      - run: uv run pytest tests/e2e/ -q
+        env:
+          TEST_ZOTERO_LOCAL: "false"
+          TEST_ZOTERO_API_KEY: ${{ secrets.TEST_ZOTERO_API_KEY }}
+          TEST_ZOTERO_LIBRARY_ID: ${{ secrets.TEST_ZOTERO_LIBRARY_ID }}
+          TEST_ZOTERO_LIBRARY_TYPE: user
+          TEST_COLLECTION_KEY: ${{ secrets.TEST_COLLECTION_KEY }}


### PR DESCRIPTION
- Run ruff, black, mypy and parallel unit tests on every push/PR
- E2E tests with Zotero API via repository secrets (skipped for fork PRs)
- Lint and unit jobs run in parallel; e2e depends on unit passing

## Summary by Sourcery

Add a GitHub Actions CI workflow to automatically lint, type-check, and test the project on pushes and pull requests.

CI:
- Introduce a CI workflow that runs ruff, black, and mypy on source and test directories for linting and type checking.
- Add a unit test job that executes pytest in parallel against the unit test suite.
- Add an end-to-end test job that runs against the Zotero API using repository secrets, executing only on pushes or non-fork pull requests and depending on unit tests passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a CI pipeline that runs code quality checks, unit tests, and end-to-end tests on pushes and pull requests.
  * End-to-end tests run conditionally for direct pushes and non-fork pull requests to protect sensitive runtime configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->