### PR TITLE
refactor: pluggable fulltext sources via entry_points

### DIFF
--- a/run-mcp.sh
+++ b/run-mcp.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+set -a
+source "$SCRIPT_DIR/.env"
+set +a
+exec "$SCRIPT_DIR/.venv/bin/python" -m yazot.mcp_server

--- a/tests/e2e/test_update_tags.py
+++ b/tests/e2e/test_update_tags.py
@@ -1,0 +1,283 @@
+"""E2E tests for update_item_tags MCP tool."""
+
+from typing import TYPE_CHECKING
+
+import pytest
+from fastmcp import Client
+from fastmcp.exceptions import ToolError
+
+from tests.e2e.conftest import parse_tool_result_dict
+from yazot.mcp_server import mcp
+from yazot.zotero_client import ZoteroClient
+
+if TYPE_CHECKING:
+    from tests.e2e.test_helpers import ZoteroTestDataManager
+
+
+class TestUpdateItemTagsAdd:
+    """Tests for mode='add' (default)."""
+
+    @pytest.mark.asyncio
+    async def test_add_new_tags(
+        self,
+        test_data_manager: "ZoteroTestDataManager",
+        test_zotero_client: ZoteroClient,
+    ) -> None:
+        """Adding new tags to an item with no tags."""
+        items = await test_data_manager.create_test_items(1)
+        item_key = items[0].key
+
+        async with Client(mcp) as client:
+            result = await client.call_tool(
+                "update_item_tags",
+                arguments={"item_key": item_key, "tags": ["new-tag-1", "new-tag-2"]},
+            )
+        data = parse_tool_result_dict(result)
+
+        assert data["changed"] is True
+        assert data["mode"] == "add"
+        assert "new-tag-1" in data["tags_after"]
+        assert "new-tag-2" in data["tags_after"]
+
+        # Verify via direct API
+        updated = await test_zotero_client.get_item(item_key)
+        assert "new-tag-1" in updated.tags
+        assert "new-tag-2" in updated.tags
+
+    @pytest.mark.asyncio
+    async def test_add_duplicate_tags_no_change(
+        self,
+        test_data_manager: "ZoteroTestDataManager",
+    ) -> None:
+        """Adding tags that already exist results in changed=False."""
+        items = await test_data_manager.create_test_items(1)
+        item_key = items[0].key
+
+        async with Client(mcp) as client:
+            # First add
+            await client.call_tool(
+                "update_item_tags",
+                arguments={"item_key": item_key, "tags": ["existing"]},
+            )
+            # Second add — same tag
+            result = await client.call_tool(
+                "update_item_tags",
+                arguments={"item_key": item_key, "tags": ["existing"]},
+            )
+        data = parse_tool_result_dict(result)
+
+        assert data["changed"] is False
+        assert data["tags_before"] == data["tags_after"]
+
+    @pytest.mark.asyncio
+    async def test_add_preserves_existing_tag_types(
+        self,
+        collection_key_items_with_tags: str,
+        test_zotero_client: ZoteroClient,
+    ) -> None:
+        """Adding new tags preserves type of existing auto-tags (type=0) and creates new with type=1."""
+        # Get an item with auto tags (type=0)
+        async with Client(mcp) as client:
+            from tests.e2e.conftest import parse_tool_result
+            from yazot.models import SearchCollectionResponse
+
+            items_result = await client.call_tool(
+                "get_collection_items",
+                arguments={"collection_key": collection_key_items_with_tags},
+            )
+            items = parse_tool_result(items_result, SearchCollectionResponse).items
+
+        # Find item with auto tags
+        auto_item = next(
+            (i for i in items if any(t.type == 0 for t in i.data.tags)),
+            None,
+        )
+        assert auto_item is not None, "Test fixture should have items with auto-tags"
+
+        async with Client(mcp) as client:
+            result = await client.call_tool(
+                "update_item_tags",
+                arguments={"item_key": auto_item.key, "tags": ["extra-tag"]},
+            )
+        data = parse_tool_result_dict(result)
+        assert data["changed"] is True
+
+        # Verify existing auto-tags preserved their type via raw API
+        raw = await test_zotero_client.get_raw_item(auto_item.key)
+        raw_tags = raw["data"]["tags"]
+        auto_tags = [t for t in raw_tags if t["type"] == 0]
+        assert len(auto_tags) > 0, "Auto-tags should be preserved with type=0"
+
+        # Verify newly added tag has type=1
+        extra = next((t for t in raw_tags if t["tag"] == "extra-tag"), None)
+        assert extra is not None, "Newly added tag should exist"
+        assert extra["type"] == 1, "Newly added tag should have type=1"
+
+    @pytest.mark.asyncio
+    async def test_add_empty_list_is_noop(
+        self,
+        test_data_manager: "ZoteroTestDataManager",
+    ) -> None:
+        """Adding empty list returns changed=False."""
+        items = await test_data_manager.create_test_items(1)
+        item_key = items[0].key
+
+        async with Client(mcp) as client:
+            result = await client.call_tool(
+                "update_item_tags",
+                arguments={"item_key": item_key, "tags": []},
+            )
+        data = parse_tool_result_dict(result)
+
+        assert data["changed"] is False
+
+    @pytest.mark.asyncio
+    async def test_default_mode_is_add(
+        self,
+        test_data_manager: "ZoteroTestDataManager",
+    ) -> None:
+        """Calling without mode uses 'add'."""
+        items = await test_data_manager.create_test_items(1)
+        item_key = items[0].key
+
+        async with Client(mcp) as client:
+            result = await client.call_tool(
+                "update_item_tags",
+                arguments={"item_key": item_key, "tags": ["default-mode-tag"]},
+            )
+        data = parse_tool_result_dict(result)
+
+        assert data["mode"] == "add"
+        assert data["changed"] is True
+
+
+class TestUpdateItemTagsRemove:
+    """Tests for mode='remove'."""
+
+    @pytest.mark.asyncio
+    async def test_remove_existing_tags(
+        self,
+        test_data_manager: "ZoteroTestDataManager",
+        test_zotero_client: ZoteroClient,
+    ) -> None:
+        """Removing existing tags removes them."""
+        items = await test_data_manager.create_test_items(1)
+        item_key = items[0].key
+
+        async with Client(mcp) as client:
+            # Setup: add tags
+            await client.call_tool(
+                "update_item_tags",
+                arguments={"item_key": item_key, "tags": ["keep-me", "remove-me"]},
+            )
+            # Remove one tag
+            result = await client.call_tool(
+                "update_item_tags",
+                arguments={"item_key": item_key, "tags": ["remove-me"], "mode": "remove"},
+            )
+        data = parse_tool_result_dict(result)
+
+        assert data["changed"] is True
+        assert "remove-me" not in data["tags_after"]
+        assert "keep-me" in data["tags_after"]
+
+        # Verify via direct API
+        updated = await test_zotero_client.get_item(item_key)
+        assert "remove-me" not in updated.tags
+        assert "keep-me" in updated.tags
+
+    @pytest.mark.asyncio
+    async def test_remove_nonexistent_tags_no_change(
+        self,
+        test_data_manager: "ZoteroTestDataManager",
+    ) -> None:
+        """Removing tags that don't exist returns changed=False."""
+        items = await test_data_manager.create_test_items(1)
+        item_key = items[0].key
+
+        async with Client(mcp) as client:
+            result = await client.call_tool(
+                "update_item_tags",
+                arguments={"item_key": item_key, "tags": ["nonexistent"], "mode": "remove"},
+            )
+        data = parse_tool_result_dict(result)
+
+        assert data["changed"] is False
+
+
+class TestUpdateItemTagsReplace:
+    """Tests for mode='replace'."""
+
+    @pytest.mark.asyncio
+    async def test_replace_all_tags(
+        self,
+        test_data_manager: "ZoteroTestDataManager",
+        test_zotero_client: ZoteroClient,
+    ) -> None:
+        """Replace mode sets exactly the specified tags."""
+        items = await test_data_manager.create_test_items(1)
+        item_key = items[0].key
+
+        async with Client(mcp) as client:
+            # Setup: add tags
+            await client.call_tool(
+                "update_item_tags",
+                arguments={"item_key": item_key, "tags": ["old-tag-1", "old-tag-2"]},
+            )
+            # Replace
+            result = await client.call_tool(
+                "update_item_tags",
+                arguments={"item_key": item_key, "tags": ["new-tag"], "mode": "replace"},
+            )
+        data = parse_tool_result_dict(result)
+
+        assert data["changed"] is True
+        assert data["tags_after"] == ["new-tag"]
+
+        # Verify via direct API
+        updated = await test_zotero_client.get_item(item_key)
+        assert updated.tags == ["new-tag"]
+
+    @pytest.mark.asyncio
+    async def test_replace_with_empty_clears_tags(
+        self,
+        test_data_manager: "ZoteroTestDataManager",
+        test_zotero_client: ZoteroClient,
+    ) -> None:
+        """Replace with empty list clears all tags."""
+        items = await test_data_manager.create_test_items(1)
+        item_key = items[0].key
+
+        async with Client(mcp) as client:
+            # Setup: add tags
+            await client.call_tool(
+                "update_item_tags",
+                arguments={"item_key": item_key, "tags": ["some-tag"]},
+            )
+            # Clear
+            result = await client.call_tool(
+                "update_item_tags",
+                arguments={"item_key": item_key, "tags": [], "mode": "replace"},
+            )
+        data = parse_tool_result_dict(result)
+
+        assert data["changed"] is True
+        assert data["tags_after"] == []
+
+        # Verify via direct API
+        updated = await test_zotero_client.get_item(item_key)
+        assert updated.tags == []
+
+
+class TestUpdateItemTagsErrors:
+    """Error handling tests."""
+
+    @pytest.mark.asyncio
+    async def test_nonexistent_item_raises_error(self) -> None:
+        """Non-existent item_key raises error."""
+        async with Client(mcp) as client:
+            with pytest.raises(ToolError):
+                await client.call_tool(
+                    "update_item_tags",
+                    arguments={"item_key": "NONEXISTENT999", "tags": ["x"]},
+                )

--- a/tests/unit/test_external_fulltext.py
+++ b/tests/unit/test_external_fulltext.py
@@ -1,10 +1,11 @@
 """E2E tests for fetch_external_fulltext MCP tool.
 
 Tests the full MCP tool flow via Client(mcp), mocking external HTTP calls
-(Unpaywall/CORE/Libgen) while using real MCP lifespan and TextChunker.
+(Unpaywall/CORE) while using real MCP lifespan and TextChunker.
 """
 
 import io
+from collections.abc import Iterator
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -13,6 +14,13 @@ from fastmcp.exceptions import ToolError
 from pypdf import PdfWriter
 
 from yazot.mcp_server import mcp
+
+
+@pytest.fixture(autouse=True)
+def _disable_plugins() -> Iterator[None]:
+    """Prevent installed entry_point plugins from affecting tests."""
+    with patch("yazot.mcp_server.discover_sources", return_value=[]):
+        yield
 
 
 def _make_pdf_bytes(pages: int = 1, text: str = "Sample text") -> bytes:
@@ -255,10 +263,13 @@ class TestFetchExternalFulltextNotConfigured:
 
     @pytest.fixture(autouse=True)
     def _clear_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Ensure no external fulltext config is set."""
-        monkeypatch.delenv("UNPAYWALL_EMAIL", raising=False)
-        monkeypatch.delenv("CORE_API_KEY", raising=False)
-        monkeypatch.delenv("FULLTEXT_LIBGEN_ENABLED", raising=False)
+        """Ensure no external fulltext config is set.
+
+        Must setenv to empty string (not delenv) because pydantic-settings
+        falls back to .env file values when env var is missing.
+        """
+        monkeypatch.setenv("UNPAYWALL_EMAIL", "")
+        monkeypatch.setenv("CORE_API_KEY", "")
 
     @pytest.mark.asyncio
     async def test_not_configured_raises_error(self) -> None:

--- a/tests/unit/test_fulltext_resolver.py
+++ b/tests/unit/test_fulltext_resolver.py
@@ -258,6 +258,32 @@ class TestFulltextResolver:
 
         assert source == "working"
 
+    async def test_cascade_generic_exception_continues(self) -> None:
+        """Generic exceptions from plugins don't break the cascade."""
+        s1 = make_mock_source("buggy_plugin")
+        s1.find_pdf_url = AsyncMock(side_effect=ValueError("plugin bug"))
+        s2 = make_mock_source("working", return_url="https://example.com/pdf.pdf")
+        resolver = FulltextResolver([s1, s2])
+
+        url, source = await resolver.resolve("10.1234/test", None)
+
+        assert source == "working"
+        assert url == "https://example.com/pdf.pdf"
+
+    async def test_resolve_empty_string_doi_normalized(self) -> None:
+        """Empty/whitespace DOI and title are normalized to None → raises."""
+        resolver = FulltextResolver([make_mock_source()])
+
+        with pytest.raises(FulltextNotFoundError):
+            await resolver.resolve("", "")
+
+    async def test_resolve_whitespace_only_normalized(self) -> None:
+        """Whitespace-only strings are normalized to None → raises."""
+        resolver = FulltextResolver([make_mock_source()])
+
+        with pytest.raises(FulltextNotFoundError):
+            await resolver.resolve("  ", "  \n ")
+
     async def test_cascade_title_only(self) -> None:
         s1 = make_mock_source("source", return_url="https://example.com/pdf.pdf")
         resolver = FulltextResolver([s1])

--- a/tests/unit/test_fulltext_resolver.py
+++ b/tests/unit/test_fulltext_resolver.py
@@ -1,4 +1,4 @@
-"""Tests for external fulltext resolver — Unpaywall, CORE, Libgen clients + cascade."""
+"""Tests for external fulltext resolver — Unpaywall, CORE clients + cascade."""
 
 import io
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -7,7 +7,6 @@ import pytest
 from pypdf import PdfWriter
 
 from tests.conftest import make_httpx_response
-from yazot.config import Settings
 from yazot.exceptions import (
     FulltextDownloadError,
     FulltextNotFoundError,
@@ -16,9 +15,9 @@ from yazot.exceptions import (
 from yazot.fulltext_resolver import (
     CoreClient,
     FulltextResolver,
-    LibgenClient,
     UnpaywallClient,
 )
+from yazot.fulltext_source import FulltextSource
 
 # --- Helpers ---
 
@@ -32,6 +31,18 @@ def make_pdf_bytes() -> bytes:
     return buf.getvalue()
 
 
+def make_mock_source(
+    name: str = "mock", description: str = "Mock source", return_url: str | None = None
+) -> FulltextSource:
+    """Create a mock FulltextSource."""
+    source = MagicMock(spec=FulltextSource)
+    source.name = name
+    source.description = description
+    source.find_pdf_url = AsyncMock(return_value=return_url)
+    source.aclose = AsyncMock()
+    return source
+
+
 # --- UnpaywallClient tests ---
 
 
@@ -39,6 +50,10 @@ class TestUnpaywallClient:
     @pytest.fixture
     def client(self) -> UnpaywallClient:
         return UnpaywallClient(email="test@example.com")
+
+    def test_name_and_description(self, client: UnpaywallClient) -> None:
+        assert client.name == "unpaywall"
+        assert "Unpaywall" in client.description
 
     async def test_find_pdf_url_success(self, client: UnpaywallClient) -> None:
         response_data = {
@@ -54,7 +69,7 @@ class TestUnpaywallClient:
         mock_response = make_httpx_response(json_data=response_data)
 
         with patch.object(client.client, "get", new_callable=AsyncMock, return_value=mock_response):
-            url = await client.find_pdf_url("10.1234/test")
+            url = await client.find_pdf_url(doi="10.1234/test")
 
         assert url == "https://example.com/paper.pdf"
 
@@ -71,7 +86,7 @@ class TestUnpaywallClient:
         mock_response = make_httpx_response(json_data=response_data)
 
         with patch.object(client.client, "get", new_callable=AsyncMock, return_value=mock_response):
-            url = await client.find_pdf_url("10.1234/test")
+            url = await client.find_pdf_url(doi="10.1234/test")
 
         assert url == "https://archive.org/paper.pdf"
 
@@ -79,7 +94,7 @@ class TestUnpaywallClient:
         mock_response = make_httpx_response(status_code=404)
 
         with patch.object(client.client, "get", new_callable=AsyncMock, return_value=mock_response):
-            url = await client.find_pdf_url("10.1234/nonexistent")
+            url = await client.find_pdf_url(doi="10.1234/nonexistent")
 
         assert url is None
 
@@ -93,8 +108,12 @@ class TestUnpaywallClient:
         mock_response = make_httpx_response(json_data=response_data)
 
         with patch.object(client.client, "get", new_callable=AsyncMock, return_value=mock_response):
-            url = await client.find_pdf_url("10.1234/closed")
+            url = await client.find_pdf_url(doi="10.1234/closed")
 
+        assert url is None
+
+    async def test_find_pdf_url_no_doi_returns_none(self, client: UnpaywallClient) -> None:
+        url = await client.find_pdf_url(title="Some Title")
         assert url is None
 
     async def test_find_pdf_url_server_error(self, client: UnpaywallClient) -> None:
@@ -104,7 +123,7 @@ class TestUnpaywallClient:
             patch.object(client.client, "get", new_callable=AsyncMock, return_value=mock_response),
             pytest.raises(FulltextSourceError, match="Unpaywall"),
         ):
-            await client.find_pdf_url("10.1234/test")
+            await client.find_pdf_url(doi="10.1234/test")
 
 
 # --- CoreClient tests ---
@@ -114,6 +133,10 @@ class TestCoreClient:
     @pytest.fixture
     def client(self) -> CoreClient:
         return CoreClient(api_key="test-key")
+
+    def test_name_and_description(self, client: CoreClient) -> None:
+        assert client.name == "core"
+        assert "CORE" in client.description
 
     async def test_find_pdf_url_by_doi(self, client: CoreClient) -> None:
         response_data = {
@@ -130,7 +153,7 @@ class TestCoreClient:
         mock_response = make_httpx_response(json_data=response_data)
 
         with patch.object(client.client, "get", new_callable=AsyncMock, return_value=mock_response):
-            url = await client.find_pdf_url("10.1234/test", None)
+            url = await client.find_pdf_url(doi="10.1234/test")
 
         assert url == "https://core.ac.uk/download/pdf/12345.pdf"
 
@@ -148,7 +171,7 @@ class TestCoreClient:
         mock_response = make_httpx_response(json_data=response_data)
 
         with patch.object(client.client, "get", new_callable=AsyncMock, return_value=mock_response):
-            url = await client.find_pdf_url(None, "Machine Learning Paper")
+            url = await client.find_pdf_url(title="Machine Learning Paper")
 
         assert url == "https://core.ac.uk/download/pdf/67890.pdf"
 
@@ -157,12 +180,12 @@ class TestCoreClient:
         mock_response = make_httpx_response(json_data=response_data)
 
         with patch.object(client.client, "get", new_callable=AsyncMock, return_value=mock_response):
-            url = await client.find_pdf_url("10.1234/nothing", None)
+            url = await client.find_pdf_url(doi="10.1234/nothing")
 
         assert url is None
 
     async def test_find_pdf_url_no_query(self, client: CoreClient) -> None:
-        url = await client.find_pdf_url(None, None)
+        url = await client.find_pdf_url()
         assert url is None
 
     async def test_find_pdf_url_server_error(self, client: CoreClient) -> None:
@@ -172,207 +195,88 @@ class TestCoreClient:
             patch.object(client.client, "get", new_callable=AsyncMock, return_value=mock_response),
             pytest.raises(FulltextSourceError, match="CORE"),
         ):
-            await client.find_pdf_url("10.1234/test", None)
-
-
-# --- LibgenClient tests ---
-
-
-class TestLibgenClient:
-    @pytest.fixture
-    def client(self) -> LibgenClient:
-        return LibgenClient(mirror="https://libgen.is")
-
-    async def test_find_pdf_url_success(self, client: LibgenClient) -> None:
-        html = """
-        <html><body>
-        <table class="c">
-            <tr><td><a href="/book/index.php?md5=d41d8cd98f00b204e9800998ecf8427e">Title</a></td></tr>
-        </table>
-        </body></html>
-        """
-        mock_response = make_httpx_response(
-            content=html.encode(),
-            headers={"content-type": "text/html"},
-        )
-        # Override json to return text
-        mock_response._content = html.encode()
-
-        with patch.object(client.client, "get", new_callable=AsyncMock, return_value=mock_response):
-            url = await client.find_pdf_url("Test Article Title")
-
-        assert url == "https://libgen.is/get.php?md5=d41d8cd98f00b204e9800998ecf8427e"
-
-    async def test_find_pdf_url_no_results(self, client: LibgenClient) -> None:
-        html = "<html><body><table class='c'></table></body></html>"
-        mock_response = make_httpx_response(content=html.encode())
-
-        with patch.object(client.client, "get", new_callable=AsyncMock, return_value=mock_response):
-            url = await client.find_pdf_url("Nonexistent Article")
-
-        assert url is None
-
-    async def test_find_pdf_url_server_error(self, client: LibgenClient) -> None:
-        mock_response = make_httpx_response(status_code=503)
-
-        with (
-            patch.object(client.client, "get", new_callable=AsyncMock, return_value=mock_response),
-            pytest.raises(FulltextSourceError, match="Libgen"),
-        ):
-            await client.find_pdf_url("Test")
+            await client.find_pdf_url(doi="10.1234/test")
 
 
 # --- FulltextResolver tests ---
 
 
 class TestFulltextResolver:
-    @pytest.fixture
-    def settings_all(self) -> Settings:
-        return Settings(
-            zotero_local=True,
-            unpaywall_email="test@example.com",
-            core_api_key="test-core-key",
-            fulltext_libgen_enabled=True,
-            fulltext_libgen_mirror="https://libgen.is",
-        )
-
-    @pytest.fixture
-    def settings_unpaywall_only(self) -> Settings:
-        return Settings(
-            zotero_local=True,
-            unpaywall_email="test@example.com",
-        )
-
-    @pytest.fixture
-    def settings_none(self) -> Settings:
-        return Settings(zotero_local=True)
-
-    def test_is_configured_all(self, settings_all: Settings) -> None:
-        resolver = FulltextResolver(settings_all)
+    def test_is_configured_with_sources(self) -> None:
+        source = make_mock_source()
+        resolver = FulltextResolver([source])
         assert resolver.is_configured is True
 
-    def test_is_configured_none(self, settings_none: Settings) -> None:
-        resolver = FulltextResolver(settings_none)
+    def test_is_configured_empty(self) -> None:
+        resolver = FulltextResolver([])
         assert resolver.is_configured is False
 
-    def test_libgen_not_created_when_disabled(self, settings_unpaywall_only: Settings) -> None:
-        resolver = FulltextResolver(settings_unpaywall_only)
-        assert resolver._libgen is None
-        assert resolver._unpaywall is not None
-        assert resolver._core is None
+    def test_sources_property(self) -> None:
+        s1 = make_mock_source("a")
+        s2 = make_mock_source("b")
+        resolver = FulltextResolver([s1, s2])
+        assert len(resolver.sources) == 2
+        assert resolver.sources[0].name == "a"
 
-    async def test_cascade_unpaywall_succeeds(self, settings_all: Settings) -> None:
-        resolver = FulltextResolver(settings_all)
-        assert resolver._unpaywall is not None
-        with patch.object(
-            resolver._unpaywall,
-            "find_pdf_url",
-            new_callable=AsyncMock,
-            return_value="https://pdf.com/a.pdf",
-        ):
-            url, source = await resolver.resolve("10.1234/test", "Test Title")
+    async def test_cascade_first_source_succeeds(self) -> None:
+        s1 = make_mock_source("first", return_url="https://pdf.com/a.pdf")
+        s2 = make_mock_source("second")
+        resolver = FulltextResolver([s1, s2])
+
+        url, source = await resolver.resolve("10.1234/test", "Test Title")
 
         assert url == "https://pdf.com/a.pdf"
-        assert source == "unpaywall"
+        assert source == "first"
+        s2.find_pdf_url.assert_not_called()
 
-    async def test_cascade_fallback_to_core(self, settings_all: Settings) -> None:
-        resolver = FulltextResolver(settings_all)
-        assert resolver._unpaywall is not None
-        assert resolver._core is not None
-        with (
-            patch.object(
-                resolver._unpaywall, "find_pdf_url", new_callable=AsyncMock, return_value=None
-            ),
-            patch.object(
-                resolver._core,
-                "find_pdf_url",
-                new_callable=AsyncMock,
-                return_value="https://core.ac.uk/pdf.pdf",
-            ),
-        ):
-            url, source = await resolver.resolve("10.1234/test", "Test Title")
+    async def test_cascade_fallback_to_second(self) -> None:
+        s1 = make_mock_source("first", return_url=None)
+        s2 = make_mock_source("second", return_url="https://core.ac.uk/pdf.pdf")
+        resolver = FulltextResolver([s1, s2])
+
+        url, source = await resolver.resolve("10.1234/test", "Test Title")
 
         assert url == "https://core.ac.uk/pdf.pdf"
-        assert source == "core"
+        assert source == "second"
 
-    async def test_cascade_fallback_to_libgen(self, settings_all: Settings) -> None:
-        resolver = FulltextResolver(settings_all)
-        assert resolver._unpaywall is not None
-        assert resolver._core is not None
-        assert resolver._libgen is not None
-        with (
-            patch.object(
-                resolver._unpaywall, "find_pdf_url", new_callable=AsyncMock, return_value=None
-            ),
-            patch.object(resolver._core, "find_pdf_url", new_callable=AsyncMock, return_value=None),
-            patch.object(
-                resolver._libgen,
-                "find_pdf_url",
-                new_callable=AsyncMock,
-                return_value="https://libgen.is/get.php?md5=abc",
-            ),
-        ):
-            url, source = await resolver.resolve("10.1234/test", "Test Title")
+    async def test_cascade_all_fail(self) -> None:
+        s1 = make_mock_source("first", return_url=None)
+        s2 = make_mock_source("second", return_url=None)
+        resolver = FulltextResolver([s1, s2])
 
-        assert url == "https://libgen.is/get.php?md5=abc"
-        assert source == "libgen"
-
-    async def test_cascade_all_fail(self, settings_all: Settings) -> None:
-        resolver = FulltextResolver(settings_all)
-        assert resolver._unpaywall is not None
-        assert resolver._core is not None
-        assert resolver._libgen is not None
-        with (
-            patch.object(
-                resolver._unpaywall, "find_pdf_url", new_callable=AsyncMock, return_value=None
-            ),
-            patch.object(resolver._core, "find_pdf_url", new_callable=AsyncMock, return_value=None),
-            patch.object(
-                resolver._libgen, "find_pdf_url", new_callable=AsyncMock, return_value=None
-            ),
-            pytest.raises(FulltextNotFoundError),
-        ):
+        with pytest.raises(FulltextNotFoundError):
             await resolver.resolve("10.1234/test", "Test Title")
 
-    async def test_cascade_error_continues(self, settings_all: Settings) -> None:
+    async def test_cascade_error_continues(self) -> None:
         """Source errors are non-fatal — cascade continues."""
-        resolver = FulltextResolver(settings_all)
-        assert resolver._unpaywall is not None
-        assert resolver._core is not None
-        with (
-            patch.object(
-                resolver._unpaywall,
-                "find_pdf_url",
-                new_callable=AsyncMock,
-                side_effect=FulltextSourceError("Unpaywall", "timeout"),
-            ),
-            patch.object(
-                resolver._core,
-                "find_pdf_url",
-                new_callable=AsyncMock,
-                return_value="https://core.ac.uk/pdf.pdf",
-            ),
-        ):
-            url, source = await resolver.resolve("10.1234/test", "Test Title")
+        s1 = make_mock_source("failing")
+        s1.find_pdf_url = AsyncMock(side_effect=FulltextSourceError("failing", "timeout"))
+        s2 = make_mock_source("working", return_url="https://core.ac.uk/pdf.pdf")
+        resolver = FulltextResolver([s1, s2])
 
-        assert source == "core"
+        url, source = await resolver.resolve("10.1234/test", "Test Title")
 
-    async def test_cascade_no_doi_skips_unpaywall(self, settings_all: Settings) -> None:
-        resolver = FulltextResolver(settings_all)
-        assert resolver._core is not None
-        with patch.object(
-            resolver._core,
-            "find_pdf_url",
-            new_callable=AsyncMock,
-            return_value="https://core.ac.uk/pdf.pdf",
-        ) as mock_core:
-            url, source = await resolver.resolve(None, "Test Title")
+        assert source == "working"
 
-        assert source == "core"
-        mock_core.assert_called_once_with(None, "Test Title")
+    async def test_cascade_title_only(self) -> None:
+        s1 = make_mock_source("source", return_url="https://example.com/pdf.pdf")
+        resolver = FulltextResolver([s1])
 
-    async def test_download_success(self, settings_all: Settings) -> None:
-        resolver = FulltextResolver(settings_all)
+        url, source = await resolver.resolve(None, "Test Title")
+
+        assert url == "https://example.com/pdf.pdf"
+        s1.find_pdf_url.assert_called_once_with(title="Test Title")
+
+    async def test_cascade_doi_and_title(self) -> None:
+        s1 = make_mock_source("source", return_url="https://example.com/pdf.pdf")
+        resolver = FulltextResolver([s1])
+
+        await resolver.resolve("10.1234/test", "Test Title")
+
+        s1.find_pdf_url.assert_called_once_with(doi="10.1234/test", title="Test Title")
+
+    async def test_download_success(self) -> None:
+        resolver = FulltextResolver([])
         pdf_bytes = make_pdf_bytes()
         mock_response = make_httpx_response(
             content=pdf_bytes,
@@ -386,8 +290,8 @@ class TestFulltextResolver:
 
         assert result == pdf_bytes
 
-    async def test_download_wrong_content_type(self, settings_all: Settings) -> None:
-        resolver = FulltextResolver(settings_all)
+    async def test_download_wrong_content_type(self) -> None:
+        resolver = FulltextResolver([])
         mock_response = make_httpx_response(
             content=b"<html>Not a PDF</html>",
             headers={"content-type": "text/html"},
@@ -399,8 +303,8 @@ class TestFulltextResolver:
         ):
             await resolver.download("https://example.com/not-a-pdf")
 
-    async def test_download_empty_pdf_body(self, settings_all: Settings) -> None:
-        resolver = FulltextResolver(settings_all)
+    async def test_download_empty_pdf_body(self) -> None:
+        resolver = FulltextResolver([])
         mock_response = make_httpx_response(
             content=b"",
             headers={"content-type": "application/pdf"},
@@ -412,8 +316,8 @@ class TestFulltextResolver:
         ):
             await resolver.download("https://example.com/empty.pdf")
 
-    async def test_download_http_error(self, settings_all: Settings) -> None:
-        resolver = FulltextResolver(settings_all)
+    async def test_download_http_error(self) -> None:
+        resolver = FulltextResolver([])
         mock_response = make_httpx_response(status_code=403)
 
         with (
@@ -422,8 +326,8 @@ class TestFulltextResolver:
         ):
             await resolver.download("https://example.com/forbidden.pdf")
 
-    def test_extract_text(self, settings_all: Settings) -> None:
-        resolver = FulltextResolver(settings_all)
+    def test_extract_text(self) -> None:
+        resolver = FulltextResolver([])
         pdf_bytes = make_pdf_bytes()
 
         with patch("yazot.pdf_utils.PdfReader") as mock_reader_cls:
@@ -437,10 +341,10 @@ class TestFulltextResolver:
 
         assert text == "Page 1 text"
 
-    def test_extract_text_pdf_parse_failure(self, settings_all: Settings) -> None:
+    def test_extract_text_pdf_parse_failure(self) -> None:
         from pypdf.errors import PdfReadError
 
-        resolver = FulltextResolver(settings_all)
+        resolver = FulltextResolver([])
         pdf_bytes = make_pdf_bytes()
 
         with (
@@ -452,8 +356,8 @@ class TestFulltextResolver:
         ):
             resolver.extract_text(pdf_bytes)
 
-    def test_extract_text_multiple_pages(self, settings_all: Settings) -> None:
-        resolver = FulltextResolver(settings_all)
+    def test_extract_text_multiple_pages(self) -> None:
+        resolver = FulltextResolver([])
         pdf_bytes = make_pdf_bytes()
 
         with patch("yazot.pdf_utils.PdfReader") as mock_reader_cls:
@@ -470,18 +374,14 @@ class TestFulltextResolver:
 
         assert text == "Page 1 text\n\nPage 2 text\n\nPage 3 text"
 
-    async def test_aclose_closes_all_clients(self, settings_all: Settings) -> None:
-        resolver = FulltextResolver(settings_all)
+    async def test_aclose_closes_all_sources(self) -> None:
+        s1 = make_mock_source("a")
+        s2 = make_mock_source("b")
+        resolver = FulltextResolver([s1, s2])
 
-        with (
-            patch.object(resolver._http, "aclose", new_callable=AsyncMock) as mock_http,
-            patch.object(resolver._unpaywall, "aclose", new_callable=AsyncMock) as mock_unpaywall,
-            patch.object(resolver._core, "aclose", new_callable=AsyncMock) as mock_core,
-            patch.object(resolver._libgen, "aclose", new_callable=AsyncMock) as mock_libgen,
-        ):
+        with patch.object(resolver._http, "aclose", new_callable=AsyncMock) as mock_http:
             await resolver.aclose()
 
         mock_http.assert_called_once()
-        mock_unpaywall.assert_called_once()
-        mock_core.assert_called_once()
-        mock_libgen.assert_called_once()
+        s1.aclose.assert_called_once()
+        s2.aclose.assert_called_once()

--- a/tests/unit/test_fulltext_resolver.py
+++ b/tests/unit/test_fulltext_resolver.py
@@ -385,3 +385,16 @@ class TestFulltextResolver:
         mock_http.assert_called_once()
         s1.aclose.assert_called_once()
         s2.aclose.assert_called_once()
+
+    async def test_aclose_continues_on_source_error(self) -> None:
+        """One broken source.aclose() must not prevent closing the rest."""
+        s1 = make_mock_source("broken")
+        s1.aclose = AsyncMock(side_effect=RuntimeError("close failed"))
+        s2 = make_mock_source("ok")
+        resolver = FulltextResolver([s1, s2])
+
+        with patch.object(resolver._http, "aclose", new_callable=AsyncMock):
+            await resolver.aclose()
+
+        s1.aclose.assert_called_once()
+        s2.aclose.assert_called_once()

--- a/tests/unit/test_fulltext_source.py
+++ b/tests/unit/test_fulltext_source.py
@@ -1,0 +1,97 @@
+"""Tests for fulltext source protocol and plugin discovery."""
+
+from unittest.mock import MagicMock, patch
+
+from yazot.fulltext_source import ENTRY_POINT_GROUP, FulltextSource, discover_sources
+
+
+def _make_entry_point(name: str, factory_return: FulltextSource | None) -> MagicMock:
+    """Create a mock entry point."""
+    ep = MagicMock()
+    ep.name = name
+    ep.load.return_value = MagicMock(return_value=factory_return)
+    return ep
+
+
+def _make_source(name: str = "test", description: str = "Test source") -> MagicMock:
+    source = MagicMock(spec=FulltextSource)
+    source.name = name
+    source.description = description
+    return source
+
+
+class TestDiscoverSources:
+    def test_no_plugins(self) -> None:
+        with patch("yazot.fulltext_source.importlib.metadata.entry_points", return_value=[]):
+            sources = discover_sources({})
+        assert sources == []
+
+    def test_loads_configured_plugin(self) -> None:
+        source = _make_source("libgen", "Libgen source")
+        ep = _make_entry_point("libgen", source)
+
+        with patch(
+            "yazot.fulltext_source.importlib.metadata.entry_points", return_value=[ep]
+        ) as mock_ep:
+            sources = discover_sources({"FULLTEXT_LIBGEN_MIRROR": "https://libgen.is"})
+
+        mock_ep.assert_called_once_with(group=ENTRY_POINT_GROUP)
+        assert len(sources) == 1
+        assert sources[0].name == "libgen"
+
+    def test_skips_unconfigured_plugin(self) -> None:
+        ep = _make_entry_point("libgen", None)
+
+        with patch("yazot.fulltext_source.importlib.metadata.entry_points", return_value=[ep]):
+            sources = discover_sources({})
+
+        assert sources == []
+
+    def test_skips_broken_plugin(self) -> None:
+        ep = MagicMock()
+        ep.name = "broken"
+        ep.load.side_effect = ImportError("missing dependency")
+
+        with patch("yazot.fulltext_source.importlib.metadata.entry_points", return_value=[ep]):
+            sources = discover_sources({})
+
+        assert sources == []
+
+    def test_skips_plugin_with_raising_factory(self) -> None:
+        def broken_factory(env: dict) -> None:  # type: ignore[type-arg]
+            raise RuntimeError("plugin factory failed")
+
+        ep = MagicMock()
+        ep.name = "broken"
+        ep.load.return_value = broken_factory
+
+        with patch("yazot.fulltext_source.importlib.metadata.entry_points", return_value=[ep]):
+            sources = discover_sources({})
+
+        assert sources == []
+
+    def test_multiple_plugins(self) -> None:
+        s1 = _make_source("libgen")
+        s2 = _make_source("zlibrary")
+        ep1 = _make_entry_point("libgen", s1)
+        ep2 = _make_entry_point("zlibrary", s2)
+
+        with patch(
+            "yazot.fulltext_source.importlib.metadata.entry_points", return_value=[ep1, ep2]
+        ):
+            sources = discover_sources({})
+
+        assert len(sources) == 2
+
+    def test_factory_receives_env(self) -> None:
+        source = _make_source("test")
+        ep = MagicMock()
+        ep.name = "test"
+        factory = MagicMock(return_value=source)
+        ep.load.return_value = factory
+
+        env = {"FULLTEXT_TEST_KEY": "secret"}
+        with patch("yazot.fulltext_source.importlib.metadata.entry_points", return_value=[ep]):
+            discover_sources(env)
+
+        factory.assert_called_once_with(env)

--- a/tests/unit/test_fulltext_source.py
+++ b/tests/unit/test_fulltext_source.py
@@ -83,6 +83,19 @@ class TestDiscoverSources:
 
         assert len(sources) == 2
 
+    def test_skips_malformed_plugin_object(self) -> None:
+        """Factory returns an object that doesn't satisfy FulltextSource contract."""
+        malformed = MagicMock()
+        del malformed.name  # missing required attribute
+        ep = MagicMock()
+        ep.name = "malformed"
+        ep.load.return_value = MagicMock(return_value=malformed)
+
+        with patch("yazot.fulltext_source.importlib.metadata.entry_points", return_value=[ep]):
+            sources = discover_sources({})
+
+        assert sources == []
+
     def test_factory_receives_env(self) -> None:
         source = _make_source("test")
         ep = MagicMock()

--- a/uv.lock
+++ b/uv.lock
@@ -78,15 +78,15 @@ wheels = [
 
 [[package]]
 name = "beautifulsoup4"
-version = "4.14.2"
+version = "4.14.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "soupsieve" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/77/e9/df2358efd7659577435e2177bfa69cba6c33216681af51a707193dec162a/beautifulsoup4-4.14.2.tar.gz", hash = "sha256:2a98ab9f944a11acee9cc848508ec28d9228abfd522ef0fad6a02a72e0ded69e", size = 625822, upload-time = "2025-09-29T10:05:42.613Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b0/1c6a16426d389813b48d95e26898aff79abbde42ad353958ad95cc8c9b21/beautifulsoup4-4.14.3.tar.gz", hash = "sha256:6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86", size = 627737, upload-time = "2025-11-30T15:08:26.084Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/fe/3aed5d0be4d404d12d36ab97e2f1791424d9ca39c2f754a6285d59a3b01d/beautifulsoup4-4.14.2-py3-none-any.whl", hash = "sha256:5ef6fa3a8cbece8488d66985560f97ed091e22bbc4e9c2338508a9d5de6d4515", size = 106392, upload-time = "2025-09-29T10:05:43.771Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl", hash = "sha256:0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb", size = 107721, upload-time = "2025-11-30T15:08:24.087Z" },
 ]
 
 [[package]]
@@ -1438,11 +1438,11 @@ wheels = [
 
 [[package]]
 name = "soupsieve"
-version = "2.8"
+version = "2.8.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6d/e6/21ccce3262dd4889aa3332e5a119a3491a95e8f60939870a3a035aabac0d/soupsieve-2.8.tar.gz", hash = "sha256:e2dd4a40a628cb5f28f6d4b0db8800b8f581b65bb380b97de22ba5ca8d72572f", size = 103472, upload-time = "2025-08-27T15:39:51.78Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/ae/2d9c981590ed9999a0d91755b47fc74f74de286b0f5cee14c9269041e6c4/soupsieve-2.8.3.tar.gz", hash = "sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349", size = 118627, upload-time = "2026-01-20T04:27:02.457Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/a0/bb38d3b76b8cae341dad93a2dd83ab7462e6dbcdd84d43f54ee60a8dc167/soupsieve-2.8-py3-none-any.whl", hash = "sha256:0cc76456a30e20f5d7f2e14a98a4ae2ee4e5abdc7c5ea0aafe795f344bc7984c", size = 36679, upload-time = "2025-08-27T15:39:50.179Z" },
+    { url = "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl", hash = "sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95", size = 37016, upload-time = "2026-01-20T04:27:01.012Z" },
 ]
 
 [[package]]

--- a/yazot/config.py
+++ b/yazot/config.py
@@ -24,11 +24,9 @@ class Settings(BaseSettings):
     # Only applies in web mode; local mode has no rate limits.
     web_zotero_max_concurrent_requests: int = Field(default=5, ge=1)
 
-    # External fulltext retrieval
+    # External fulltext retrieval (built-in sources)
     unpaywall_email: str | None = Field(default=None)
     core_api_key: str | None = Field(default=None)
-    fulltext_libgen_enabled: bool = Field(default=False)
-    fulltext_libgen_mirror: str = Field(default="https://libgen.is")
 
     @model_validator(mode="after")
     def validate_credentials(self) -> Self:

--- a/yazot/crossref_client.py
+++ b/yazot/crossref_client.py
@@ -284,7 +284,7 @@ class CrossrefClient:
             "book": "book",
             "proceedings-article": "conferencePaper",
             "report": "report",
-            "dataset": "document",
+            "dataset": "dataset",
             "posted-content": "preprint",
         }
         return type_mapping.get(crossref_type, "journalArticle")

--- a/yazot/fulltext_resolver.py
+++ b/yazot/fulltext_resolver.py
@@ -221,6 +221,15 @@ class FulltextResolver:
             raise FulltextDownloadError("pdf", str(e)) from e
 
     async def aclose(self) -> None:
-        await self._http.aclose()
-        for source in self._sources:
-            await source.aclose()
+        try:
+            await self._http.aclose()
+        finally:
+            for source in self._sources:
+                try:
+                    await source.aclose()
+                except Exception:
+                    logger.warning(
+                        "Failed to close fulltext source %s",
+                        source.name,
+                        exc_info=True,
+                    )

--- a/yazot/fulltext_resolver.py
+++ b/yazot/fulltext_resolver.py
@@ -178,10 +178,9 @@ class FulltextResolver:
             try:
                 if doi is not None:
                     url = await source.find_pdf_url(doi=doi, title=title)
-                elif title is not None:
-                    url = await source.find_pdf_url(title=title)
                 else:
-                    continue
+                    # title is guaranteed non-None by the early guard above
+                    url = await source.find_pdf_url(title=title)  # type: ignore[arg-type]
                 if url:
                     return url, source.name
             except FulltextSourceError as e:

--- a/yazot/fulltext_resolver.py
+++ b/yazot/fulltext_resolver.py
@@ -4,11 +4,10 @@ import logging
 from urllib.parse import quote
 
 import httpx
-from bs4 import BeautifulSoup
 from pydantic import BaseModel, Field
 
-from .config import Settings
 from .exceptions import FulltextDownloadError, FulltextNotFoundError, FulltextSourceError
+from .fulltext_source import FulltextSource
 from .pdf_utils import extract_text_from_pdf
 
 logger = logging.getLogger(__name__)
@@ -51,7 +50,7 @@ class CoreSearchResponse(BaseModel):
     model_config = {"populate_by_name": True, "extra": "allow"}
 
 
-# --- API Clients ---
+# --- Built-in sources ---
 
 
 class UnpaywallClient:
@@ -64,8 +63,18 @@ class UnpaywallClient:
         self.email = email
         self.client = httpx.AsyncClient(timeout=self.TIMEOUT)
 
-    async def find_pdf_url(self, doi: str) -> str | None:
+    @property
+    def name(self) -> str:
+        return "unpaywall"
+
+    @property
+    def description(self) -> str:
+        return "Unpaywall — legal open-access PDF discovery by DOI"
+
+    async def find_pdf_url(self, *, doi: str | None = None, title: str | None = None) -> str | None:
         """Find open-access PDF URL for a DOI via Unpaywall."""
+        if not doi:
+            return None
         url = f"{self.BASE_URL}/{quote(doi, safe='')}"
         try:
             response = await self.client.get(url, params={"email": self.email})
@@ -102,7 +111,15 @@ class CoreClient:
             headers={"Authorization": f"Bearer {api_key}"},
         )
 
-    async def find_pdf_url(self, doi: str | None, title: str | None) -> str | None:
+    @property
+    def name(self) -> str:
+        return "core"
+
+    @property
+    def description(self) -> str:
+        return "CORE — academic fulltext aggregator, search by DOI or title"
+
+    async def find_pdf_url(self, *, doi: str | None = None, title: str | None = None) -> str | None:
         """Search CORE for a PDF download URL."""
         query = f'doi:"{doi}"' if doi else title
         if not query:
@@ -129,92 +146,52 @@ class CoreClient:
         await self.client.aclose()
 
 
-class LibgenClient:
-    """Client for Library Genesis article search (gray zone)."""
-
-    TIMEOUT = 45
-
-    def __init__(self, mirror: str) -> None:
-        self.mirror = mirror.rstrip("/")
-        self.client = httpx.AsyncClient(timeout=self.TIMEOUT, follow_redirects=True)
-
-    async def find_pdf_url(self, title: str) -> str | None:
-        """Search Libgen Sci-Tech for article PDF URL by title."""
-        search_url = f"{self.mirror}/search.php"
-        try:
-            response = await self.client.get(
-                search_url,
-                params={"req": title, "res": "25", "column": "title"},
-            )
-            response.raise_for_status()
-        except httpx.HTTPStatusError as e:
-            raise FulltextSourceError("Libgen", f"HTTP {e.response.status_code}") from e
-        except httpx.RequestError as e:
-            raise FulltextSourceError("Libgen", str(e)) from e
-
-        soup = BeautifulSoup(response.text, "html.parser")
-        # Libgen search results table contains MD5 links
-        for link in soup.select("table.c a[href*='md5=']"):
-            href = link.get("href", "")
-            if isinstance(href, str) and "md5=" in href:
-                # Extract MD5 and build direct download URL
-                md5_start = href.index("md5=") + 4
-                md5 = href[md5_start : md5_start + 32]
-                if len(md5) == 32:
-                    return f"{self.mirror}/get.php?md5={md5}"
-        return None
-
-    async def aclose(self) -> None:
-        await self.client.aclose()
-
-
 # --- Cascade Resolver ---
 
 
 class FulltextResolver:
-    """Cascading resolver: Unpaywall → CORE → Libgen (if enabled)."""
+    """Cascading resolver: iterates over sources in order until one returns a PDF URL."""
 
-    def __init__(self, settings: Settings) -> None:
-        self._unpaywall = (
-            UnpaywallClient(settings.unpaywall_email) if settings.unpaywall_email else None
-        )
-        self._core = CoreClient(settings.core_api_key) if settings.core_api_key else None
-        self._libgen = (
-            LibgenClient(settings.fulltext_libgen_mirror)
-            if settings.fulltext_libgen_enabled
-            else None
-        )
+    def __init__(self, sources: list[FulltextSource]) -> None:
+        self._sources = sources
         self._http = httpx.AsyncClient(timeout=60, follow_redirects=True)
 
     @property
     def is_configured(self) -> bool:
-        return any([self._unpaywall, self._core, self._libgen])
+        return len(self._sources) > 0
+
+    @property
+    def sources(self) -> list[FulltextSource]:
+        return list(self._sources)
 
     async def resolve(self, doi: str | None, title: str | None) -> tuple[str, str]:
         """Find PDF URL through cascade. Returns (pdf_url, source_name)."""
-        if doi and self._unpaywall:
-            try:
-                url = await self._unpaywall.find_pdf_url(doi)
-                if url:
-                    return url, "unpaywall"
-            except FulltextSourceError as e:
-                logger.warning("Unpaywall failed for %s: %s", doi, e)
+        if doi is not None:
+            doi = doi.strip() or None
+        if title is not None:
+            title = title.strip() or None
 
-        if self._core and (doi or title):
-            try:
-                url = await self._core.find_pdf_url(doi, title)
-                if url:
-                    return url, "core"
-            except FulltextSourceError as e:
-                logger.warning("CORE failed for doi=%s title=%s: %s", doi, title, e)
+        if doi is None and title is None:
+            raise FulltextNotFoundError(doi=doi, title=title)
 
-        if title and self._libgen:
+        for source in self._sources:
             try:
-                url = await self._libgen.find_pdf_url(title)
+                if doi is not None:
+                    url = await source.find_pdf_url(doi=doi, title=title)
+                elif title is not None:
+                    url = await source.find_pdf_url(title=title)
+                else:
+                    continue
                 if url:
-                    return url, "libgen"
+                    return url, source.name
             except FulltextSourceError as e:
-                logger.warning("Libgen failed for %s: %s", title, e)
+                logger.warning("%s failed: %s", source.name, e)
+            except Exception:
+                logger.warning(
+                    "Unexpected failure from fulltext source %s",
+                    source.name,
+                    exc_info=True,
+                )
 
         raise FulltextNotFoundError(doi=doi, title=title)
 
@@ -246,9 +223,5 @@ class FulltextResolver:
 
     async def aclose(self) -> None:
         await self._http.aclose()
-        if self._unpaywall:
-            await self._unpaywall.aclose()
-        if self._core:
-            await self._core.aclose()
-        if self._libgen:
-            await self._libgen.aclose()
+        for source in self._sources:
+            await source.aclose()

--- a/yazot/fulltext_source.py
+++ b/yazot/fulltext_source.py
@@ -1,0 +1,61 @@
+"""Fulltext source plugin protocol and discovery via entry_points."""
+
+import importlib.metadata
+import logging
+from collections.abc import Mapping
+from typing import Protocol, overload, runtime_checkable
+
+logger = logging.getLogger(__name__)
+
+ENTRY_POINT_GROUP = "yazot.fulltext_sources"
+
+
+@runtime_checkable
+class FulltextSource(Protocol):
+    """Protocol for fulltext PDF sources (built-in and plugins).
+
+    Each source searches for a PDF URL given a DOI and/or title.
+    At least one of doi or title must be provided (enforced via overloads).
+    """
+
+    @property
+    def name(self) -> str: ...
+
+    @property
+    def description(self) -> str: ...
+
+    @overload
+    async def find_pdf_url(self, *, doi: str, title: str | None = ...) -> str | None: ...
+    @overload
+    async def find_pdf_url(self, *, doi: None = ..., title: str) -> str | None: ...
+
+    async def aclose(self) -> None: ...
+
+
+def discover_sources(env: Mapping[str, str]) -> list[FulltextSource]:
+    """Load fulltext source plugins registered via entry_points.
+
+    Each entry point must be a factory: (env: Mapping[str, str]) -> FulltextSource | None.
+    Returns None if not configured (e.g. missing required env vars).
+    """
+    sources: list[FulltextSource] = []
+    eps = importlib.metadata.entry_points(group=ENTRY_POINT_GROUP)
+    for ep in eps:
+        try:
+            factory = ep.load()
+            source = factory(env)
+            if source is not None:
+                if (
+                    not isinstance(getattr(source, "name", None), str)
+                    or not isinstance(getattr(source, "description", None), str)
+                    or not callable(getattr(source, "find_pdf_url", None))
+                    or not callable(getattr(source, "aclose", None))
+                ):
+                    raise TypeError(f"Plugin {ep.name} returned an invalid fulltext source")
+                sources.append(source)
+                logger.info("Loaded fulltext source plugin: %s", source.name)
+            else:
+                logger.debug("Plugin %s returned None (not configured)", ep.name)
+        except Exception:
+            logger.warning("Failed to load fulltext source plugin: %s", ep.name, exc_info=True)
+    return sources

--- a/yazot/mcp_server.py
+++ b/yazot/mcp_server.py
@@ -59,13 +59,21 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[dict[str, Any]]:
         builtin_sources.append(CoreClient(settings.core_api_key))
     # Merge .env file values with os.environ for plugin discovery.
     # pydantic-settings loads .env internally but doesn't export to os.environ.
-    # Keys are uppercased for consistency (pydantic-settings is case-insensitive,
-    # but plugins expect uppercase env var names by convention).
+    # Read the same env files as Settings to keep plugin config consistent.
     from dotenv import dotenv_values
 
-    plugin_env: dict[str, str] = {
-        k.upper(): v for k, v in dotenv_values(".env").items() if v is not None
-    }
+    plugin_env: dict[str, str] = {}
+    raw_env_files = Settings.model_config.get("env_file", ())
+    if raw_env_files is None:
+        env_files: tuple[str, ...] = ()
+    elif isinstance(raw_env_files, str | os.PathLike):
+        env_files = (str(raw_env_files),)
+    else:
+        env_files = tuple(str(f) for f in raw_env_files)
+    for env_file in env_files:
+        plugin_env.update(
+            {k.upper(): v for k, v in dotenv_values(env_file).items() if v is not None}
+        )
     plugin_env.update({k.upper(): v for k, v in os.environ.items()})
     plugin_sources = discover_sources(plugin_env)
     resolver = FulltextResolver(builtin_sources + plugin_sources)

--- a/yazot/mcp_server.py
+++ b/yazot/mcp_server.py
@@ -5,7 +5,7 @@ import os
 import tempfile
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
-from typing import Any
+from typing import Any, Literal
 
 import httpx
 from fastmcp import Context, FastMCP
@@ -21,6 +21,7 @@ from .models import (
     CollectionCreate,
     ExternalFulltextResponse,
     FulltextResponse,
+    ItemUpdate,
     Note,
     SearchCollectionResponse,
     VerificationResult,
@@ -112,6 +113,12 @@ If `has_more=True`, call `get_next_chunk` (search results) or `get_next_fulltext
 1. Find item using search or get_collection_items
 2. `remove_item(item_key="ABC123", collection_key="COL456")` — smart removal
 3. Or `remove_item(item_key="ABC123", from_library=True)` — force delete from library
+
+**Manage item tags:**
+1. Find item using search or get_collection_items
+2. `update_item_tags(item_key="ABC123", tags=["important", "to-read"])` — add tags (default)
+3. `update_item_tags(item_key="ABC123", tags=["to-read"], mode="remove")` — remove specific tags
+4. `update_item_tags(item_key="ABC123", tags=["reviewed"], mode="replace")` — replace all tags
 
 **Create and verify notes:**
 1. Find item using search or get_collection_items tool
@@ -811,6 +818,92 @@ async def remove_item(
         "action": "removed_from_collection",
         "item_key": item_key,
         "collection_key": collection_key_str,
+    }
+
+
+@mcp.tool(annotations=ToolAnnotations(readOnlyHint=False, idempotentHint=True))
+async def update_item_tags(
+    item_key: str,
+    tags: list[str],
+    ctx: Context,
+    mode: Literal["add", "remove", "replace"] = "add",
+) -> dict[str, Any]:
+    """
+    Add, remove, or replace tags on a Zotero item.
+
+    Manages tags on an existing item with three modes:
+    - 'add' (default): append tags to existing ones, duplicates are ignored
+    - 'remove': remove specified tags, missing tags are silently ignored
+    - 'replace': replace all tags with the provided list, empty list clears all tags
+
+    New tags are created with type=1 (manual/user-created).
+    Existing tags preserve their original type.
+
+    Args:
+        item_key: The Zotero item key to update tags on
+        tags: List of tag names to add, remove, or set
+        mode: Operation mode — 'add', 'remove', or 'replace' (default: 'add')
+
+    Returns:
+        Dictionary with item_key, mode, tags_before, tags_after, and changed flag
+
+    Examples:
+        # Add tags to an item
+        update_item_tags(item_key="ABC123", tags=["important", "to-read"])
+
+        # Remove specific tags
+        update_item_tags(item_key="ABC123", tags=["to-read"], mode="remove")
+
+        # Replace all tags
+        update_item_tags(item_key="ABC123", tags=["reviewed"], mode="replace")
+
+        # Clear all tags
+        update_item_tags(item_key="ABC123", tags=[], mode="replace")
+    """
+    router: ZoteroClientRouter = _deps(ctx)["router"]
+
+    item = await router.get_item(item_key)
+    existing_tags = item.data.tags
+    tags_before = [t.tag for t in existing_tags]
+
+    if mode == "replace":
+        new_tags = [ZoteroTag(tag=t, type=1) for t in tags]
+    elif mode == "add":
+        existing_names: set[str] = set()
+        new_tags = []
+        for existing in existing_tags:
+            if existing.tag not in existing_names:
+                existing_names.add(existing.tag)
+                new_tags.append(existing)
+        for tag_name in tags:
+            if tag_name not in existing_names:
+                new_tags.append(ZoteroTag(tag=tag_name, type=1))
+                existing_names.add(tag_name)
+    elif mode == "remove":
+        remove_set = set(tags)
+        new_tags = [t for t in existing_tags if t.tag not in remove_set]
+    else:
+        raise ZoteroError(f"Invalid mode: {mode!r}. Use 'add', 'remove', or 'replace'.")
+
+    tags_after = [t.tag for t in new_tags]
+
+    if tags_before == tags_after:
+        return {
+            "item_key": item_key,
+            "mode": mode,
+            "tags_before": tags_before,
+            "tags_after": tags_after,
+            "changed": False,
+        }
+
+    await router.update_item(item_key, ItemUpdate(tags=new_tags))
+
+    return {
+        "item_key": item_key,
+        "mode": mode,
+        "tags_before": tags_before,
+        "tags_after": tags_after,
+        "changed": True,
     }
 
 

--- a/yazot/mcp_server.py
+++ b/yazot/mcp_server.py
@@ -16,7 +16,8 @@ from .client_router import ZoteroClientRouter
 from .config import Settings
 from .crossref_client import CrossrefClient
 from .exceptions import ConfigurationError, ZoteroError, ZoteroNotFoundError
-from .fulltext_resolver import FulltextResolver
+from .fulltext_resolver import CoreClient, FulltextResolver, UnpaywallClient
+from .fulltext_source import FulltextSource, discover_sources
 from .models import (
     CollectionCreate,
     ExternalFulltextResponse,
@@ -50,7 +51,24 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[dict[str, Any]]:
     text_chunker = TextChunker(max_tokens=settings.max_chunk_size)
     note_manager = NoteManager(router)
     verifier = NoteVerifier(note_manager, router)
-    resolver = FulltextResolver(settings)
+    # Build fulltext sources: built-in + plugins
+    builtin_sources: list[FulltextSource] = []
+    if settings.unpaywall_email:
+        builtin_sources.append(UnpaywallClient(settings.unpaywall_email))
+    if settings.core_api_key:
+        builtin_sources.append(CoreClient(settings.core_api_key))
+    # Merge .env file values with os.environ for plugin discovery.
+    # pydantic-settings loads .env internally but doesn't export to os.environ.
+    # Keys are uppercased for consistency (pydantic-settings is case-insensitive,
+    # but plugins expect uppercase env var names by convention).
+    from dotenv import dotenv_values
+
+    plugin_env: dict[str, str] = {
+        k.upper(): v for k, v in dotenv_values(".env").items() if v is not None
+    }
+    plugin_env.update({k.upper(): v for k, v in os.environ.items()})
+    plugin_sources = discover_sources(plugin_env)
+    resolver = FulltextResolver(builtin_sources + plugin_sources)
 
     try:
         yield {
@@ -623,12 +641,10 @@ async def fetch_external_fulltext(
     title: str | None = None,
 ) -> ExternalFulltextResponse:
     """
-    Fetch full text of an article from external open-access sources.
+    Fetch full text of an article from external sources.
 
-    Searches external sources in cascade order:
-    1. Unpaywall (by DOI) - legal open-access repository
-    2. CORE (by DOI or title) - academic aggregator
-    3. Libgen (by title) - only if explicitly enabled in config
+    Searches configured sources in cascade order (built-in + plugins).
+    Use resource://fulltext-sources to see available sources.
 
     If item_key is provided, DOI/title are extracted from the Zotero item automatically,
     and the downloaded PDF is attached to the item.
@@ -638,7 +654,7 @@ async def fetch_external_fulltext(
     Args:
         item_key: Optional Zotero item key — extracts DOI/title and attaches PDF
         doi: DOI identifier (preferred for best results)
-        title: Article title (used for CORE and libgen search)
+        title: Article title
 
     Returns:
         ExternalFulltextResponse with extracted text content (potentially chunked)
@@ -655,7 +671,8 @@ async def fetch_external_fulltext(
     if not resolver.is_configured:
         raise ConfigurationError(
             "External fulltext retrieval is not configured. "
-            "Set UNPAYWALL_EMAIL and/or CORE_API_KEY in .env"
+            "Set UNPAYWALL_EMAIL and/or CORE_API_KEY in .env, "
+            "or install a fulltext source plugin."
         )
 
     # Extract DOI/title from Zotero item if item_key provided
@@ -829,6 +846,21 @@ async def list_collections(ctx: Context) -> str:
         if coll.parent_collection:
             parent_info = f", parent: {coll.parent_collection}"
         result += f"- {coll.name} (key: {coll.key}, items: {coll.num_items}{parent_info})\n"
+
+    return result
+
+
+@mcp.resource("resource://fulltext-sources")
+async def list_fulltext_sources(ctx: Context) -> str:
+    """List configured fulltext sources (built-in and plugins)."""
+    resolver: FulltextResolver = _deps(ctx)["resolver"]
+
+    if not resolver.sources:
+        return "No fulltext sources configured."
+
+    result = "Configured fulltext sources:\n\n"
+    for source in resolver.sources:
+        result += f"- {source.name}: {source.description}\n"
 
     return result
 

--- a/yazot/models.py
+++ b/yazot/models.py
@@ -109,6 +109,9 @@ class ZoteroItemData(BaseModel):
     url: str | None = None
     isbn: str | None = Field(None, alias="ISBN")
     issn: str | None = Field(None, alias="ISSN")
+    pmid: str | None = Field(None, alias="PMID")
+    pmcid: str | None = Field(None, alias="PMCID")
+    citation_key: str | None = Field(None, alias="citationKey")
 
     # Publication fields (journalArticle, conferencePaper)
     publication_title: str | None = Field(None, alias="publicationTitle")
@@ -121,6 +124,10 @@ class ZoteroItemData(BaseModel):
 
     # Book fields
     publisher: str | None = None
+    place: str | None = None
+    original_date: str | None = Field(None, alias="originalDate")
+    original_publisher: str | None = Field(None, alias="originalPublisher")
+    original_place: str | None = Field(None, alias="originalPlace")
 
     # Note fields
     note: str | None = None
@@ -299,6 +306,9 @@ class ItemCreate(BaseModel):
     url: str | None = None
     isbn: str | None = Field(None, alias="ISBN")
     issn: str | None = Field(None, alias="ISSN")
+    pmid: str | None = Field(None, alias="PMID")
+    pmcid: str | None = Field(None, alias="PMCID")
+    citation_key: str | None = Field(None, alias="citationKey")
 
     # Publication fields (journalArticle, conferencePaper)
     publication_title: str | None = Field(None, alias="publicationTitle")
@@ -311,6 +321,10 @@ class ItemCreate(BaseModel):
 
     # Book fields
     publisher: str | None = None
+    place: str | None = None
+    original_date: str | None = Field(None, alias="originalDate")
+    original_publisher: str | None = Field(None, alias="originalPublisher")
+    original_place: str | None = Field(None, alias="originalPlace")
 
     # Note fields
     note: str | None = None
@@ -340,6 +354,9 @@ class ItemUpdate(BaseModel):
     url: str | None = None
     isbn: str | None = Field(None, alias="ISBN")
     issn: str | None = Field(None, alias="ISSN")
+    pmid: str | None = Field(None, alias="PMID")
+    pmcid: str | None = Field(None, alias="PMCID")
+    citation_key: str | None = Field(None, alias="citationKey")
 
     # Publication fields
     publication_title: str | None = Field(None, alias="publicationTitle")
@@ -352,6 +369,10 @@ class ItemUpdate(BaseModel):
 
     # Book fields
     publisher: str | None = None
+    place: str | None = None
+    original_date: str | None = Field(None, alias="originalDate")
+    original_publisher: str | None = Field(None, alias="originalPublisher")
+    original_place: str | None = Field(None, alias="originalPlace")
 
     # Note fields
     note: str | None = None


### PR DESCRIPTION
## Summary

- Fulltext sources now implement a `FulltextSource` Protocol — plugins register via Python `entry_points` (`yazot.fulltext_sources` group) and are discovered automatically at startup
- LibgenClient removed from main codebase (moved to separate `yazot-source-libgen` package); `beautifulsoup4` dropped from dependencies
- New MCP resource `resource://fulltext-sources` exposes active sources to clients

## Summary by Sourcery

Refactor external fulltext resolution to use a pluggable source protocol with built-in clients and entry-point–based plugins, and expose configured sources via a new MCP resource.

New Features:
- Introduce a FulltextSource protocol and entry-point–based plugin discovery for external fulltext providers.
- Add a new MCP resource to list configured fulltext sources and their descriptions.

Bug Fixes:
- Ensure Unpaywall and CORE clients handle missing DOI/title inputs safely when resolving fulltext.

Enhancements:
- Refactor FulltextResolver into a generic cascading resolver over an injected list of sources instead of hardcoded clients.
- Add metadata (name and description) to built-in Unpaywall and CORE sources for better introspection and UX.
- Simplify configuration by removing Libgen-specific settings and wiring built-in sources and plugins through the MCP server lifecycle.

Build:
- Drop the beautifulsoup4 dependency now that Libgen scraping is moved out to a plugin package.

Tests:
- Rework fulltext resolver tests around configurable sources rather than Settings, and expand coverage for cascade behavior and download/extract routines.
- Add dedicated tests for the FulltextSource protocol and plugin discovery via entry points.
- Update Unpaywall and CORE client tests to cover new signatures and metadata properties.
- Adapt external fulltext configuration tests to the new plugin-aware setup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plugin-based fulltext sources supported; new endpoint lists configured sources.

* **Removed Features**
  * Libgen removed as a built-in fulltext retrieval source.

* **Changes**
  * Fulltext resolver refactored to use an injected, ordered source list (built-in + plugins); resolves by cascading until a PDF is found and trims inputs.

* **Tests**
  * Expanded unit tests for resolver, source discovery, and built-in clients; discovery behavior now covered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->