### PR TITLE
fix: use local mypy hook and document pydantic-settings pitfalls

### DIFF
--- a/.claude/rules/testing-pydantic-settings.md
+++ b/.claude/rules/testing-pydantic-settings.md
@@ -1,0 +1,6 @@
+# Testing with pydantic-settings
+
+When clearing env vars in tests, use `monkeypatch.setenv("VAR", "")` instead of
+`monkeypatch.delenv("VAR")` — pydantic-settings falls back to `.env` file values
+when the env var is missing from `os.environ`, so `delenv` doesn't actually clear
+the value from Settings' perspective.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,12 +11,15 @@ repos:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
 
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.17.1
+  - repo: local
     hooks:
       - id: mypy
-        args: [--ignore-missing-imports]
-        additional_dependencies: []
+        name: mypy
+        entry: uv run mypy
+        language: system
+        types: [python]
+        pass_filenames: false
+        args: [yazot/]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,10 @@ Configuration via `.env` (pydantic-settings). Two modes:
 
 For tests: `.env.test` (auto-loaded via `conftest.py`)
 
+**Important:** pydantic-settings loads `.env` internally but does NOT export values to `os.environ`.
+Code outside Settings that needs `.env` values must use `dotenv_values()` explicitly.
+Keys in `.env` may be lowercase — normalize to uppercase when passing to external consumers.
+
 ## Conventions
 
 - All models — Pydantic v2 BaseModel (not dicts)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,8 +100,7 @@ Configuration via `.env` (pydantic-settings). Two modes:
 For tests: `.env.test` (auto-loaded via `conftest.py`)
 
 **Important:** pydantic-settings loads `.env` internally but does NOT export values to `os.environ`.
-Code outside Settings that needs `.env` values must use `dotenv_values()` explicitly.
-Keys in `.env` may be lowercase — normalize to uppercase when passing to external consumers.
+Tests use `load_dotenv(".env.test", override=True)` in `conftest.py` to export test config to `os.environ`.
 
 ## Conventions
 


### PR DESCRIPTION
## Summary

- pre-commit mypy hook (`mirrors-mypy`) ran in isolated venv without project dependencies, causing consistent failures — replaced with local `uv run mypy` hook that uses the project venv
- Documented pydantic-settings `.env` loading behavior (doesn't export to `os.environ`) in CLAUDE.md
- Added `.claude/rules/testing-pydantic-settings.md` — use `setenv("")` instead of `delenv` in tests

## Summary by Sourcery

Replace the mypy pre-commit hook with a local project-based invocation and document pydantic-settings environment variable behavior, including testing conventions.

Enhancements:
- Switch the pre-commit mypy hook to a local `uv run mypy` command that uses the project environment instead of the isolated mirrors-mypy hook.

Documentation:
- Document pydantic-settings `.env` loading behavior and its lack of propagation to `os.environ` in CLAUDE.md.
- Add testing guidance for pydantic-settings regarding environment variable clearing semantics in `.claude/rules/testing-pydantic-settings.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for testing environment-variable behavior with pydantic-settings.
  * Recommend using setenv to clear a variable in tests rather than deleting it.
  * Clarified that pydantic-settings reads .env files but does not automatically export values to os.environ; tests explicitly load test env files.

* **Chores**
  * Updated development tool configuration for local mypy invocation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->