### PR TITLE
fix: resolve pre-existing test failures and fix pre-commit mypy

### DIFF
--- a/.claude/rules/fastmcp-serialization.md
+++ b/.claude/rules/fastmcp-serialization.md
@@ -1,0 +1,11 @@
+---
+globs: ["yazot/models.py", "yazot/mcp_server.py"]
+---
+
+# FastMCP response serialization
+
+- FastMCP generates `output_schema` via `type_adapter.json_schema(mode="serialization")`
+- `@model_serializer(mode="wrap")` on tool return types breaks this — schema degrades to `{"type": "object"}`, client gets raw dict instead of typed dataclass
+- `@model_serializer` on **nested** models (e.g. `ZoteroItem`) is fine — only top-level return types are affected
+- For slimming responses: use `to_slim_dict()` pattern (returns `model_dump(exclude_none=True)` as dict)
+- Return type annotation must stay as the Pydantic model (for schema generation), add `# type: ignore[return-value]`

--- a/.claude/rules/fastmcp-serialization.md
+++ b/.claude/rules/fastmcp-serialization.md
@@ -5,7 +5,7 @@ globs: ["yazot/models.py", "yazot/mcp_server.py"]
 # FastMCP response serialization
 
 - FastMCP generates `output_schema` via `type_adapter.json_schema(mode="serialization")`
-- `@model_serializer(mode="wrap")` on tool return types breaks this — schema degrades to `{"type": "object"}`, client gets raw dict instead of typed dataclass
+- `@model_serializer(mode="wrap")` on tool return types break this — schema degrades to `{"type": "object"}`, client gets raw dict instead of typed dataclass
 - `@model_serializer` on **nested** models (e.g. `ZoteroItem`) is fine — only top-level return types are affected
 - For slimming responses: use `to_slim_dict()` pattern (returns `model_dump(exclude_none=True)` as dict)
 - Return type annotation must stay as the Pydantic model (for schema generation), add `# type: ignore[return-value]`

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,8 +15,13 @@ repos:
     rev: v1.17.1
     hooks:
       - id: mypy
-        args: [--ignore-missing-imports]
-        additional_dependencies: []
+        files: ^yazot/
+        additional_dependencies:
+          - pydantic>=2.11
+          - pydantic-settings>=2.0
+          - fastmcp>=2.0
+          - beautifulsoup4>=4.0
+          - httpx>=0.27
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0

--- a/tests/unit/test_external_fulltext.py
+++ b/tests/unit/test_external_fulltext.py
@@ -255,10 +255,10 @@ class TestFetchExternalFulltextNotConfigured:
 
     @pytest.fixture(autouse=True)
     def _clear_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Ensure no external fulltext config is set."""
-        monkeypatch.delenv("UNPAYWALL_EMAIL", raising=False)
-        monkeypatch.delenv("CORE_API_KEY", raising=False)
-        monkeypatch.delenv("FULLTEXT_LIBGEN_ENABLED", raising=False)
+        """Override .env values — delenv is not enough since pydantic-settings reads .env file."""
+        monkeypatch.setenv("UNPAYWALL_EMAIL", "")
+        monkeypatch.setenv("CORE_API_KEY", "")
+        monkeypatch.setenv("FULLTEXT_LIBGEN_ENABLED", "false")
 
     @pytest.mark.asyncio
     async def test_not_configured_raises_error(self) -> None:

--- a/tests/unit/test_fulltext_resolver.py
+++ b/tests/unit/test_fulltext_resolver.py
@@ -241,11 +241,18 @@ class TestFulltextResolver:
         return Settings(
             zotero_local=True,
             unpaywall_email="test@example.com",
+            core_api_key=None,
+            fulltext_libgen_enabled=False,
         )
 
     @pytest.fixture
     def settings_none(self) -> Settings:
-        return Settings(zotero_local=True)
+        return Settings(
+            zotero_local=True,
+            unpaywall_email=None,
+            core_api_key=None,
+            fulltext_libgen_enabled=False,
+        )
 
     def test_is_configured_all(self, settings_all: Settings) -> None:
         resolver = FulltextResolver(settings_all)


### PR DESCRIPTION
## Summary
- 3 unit tests were failing because `.env` values leaked into test fixtures via pydantic-settings — fixtures now explicitly set all fulltext config fields
- Pre-commit mypy hook was non-functional (missing pydantic dependency) — now properly configured with project deps, scoped to `yazot/` only
- Add `.claude/rules/fastmcp-serialization.md` documenting the `@model_serializer` + output_schema pitfall

## Summary by Sourcery

Resolve failing fulltext-related tests and restore mypy pre-commit checks while documenting a FastMCP serialization pitfall.

Bug Fixes:
- Stabilize fulltext resolver tests by explicitly configuring all relevant Settings fields to avoid leakage from .env via pydantic-settings.
- Ensure external fulltext configuration tests are isolated from .env contents by overriding related environment variables in fixtures.

Enhancements:
- Document FastMCP response serialization constraints and recommended patterns in a dedicated Claude rules file.

CI:
- Configure the mypy pre-commit hook with the project’s runtime dependencies and restrict it to the yazot/ package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidelines for response serialization and schema behavior, plus patterns for creating slimmer response payloads.

* **Tests**
  * Strengthened tests and fixtures to explicitly control environment/configuration values for fulltext resolution scenarios.

* **Chores**
  * Restricted type-checking to project sources and updated pre-commit mypy dependencies for accurate analysis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->