### PR TITLE
infra: move hooks to settings.json, add branch-switch guard and debounce

### DIFF
--- a/.claude/hooks/block-branch-switch.sh
+++ b/.claude/hooks/block-branch-switch.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# PreToolUse hook for Bash: блокирует git checkout/switch в основном репозитории.
+# Для переключения веток используй EnterWorktree.
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | sed -n 's/.*"command"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+[ -z "$COMMAND" ] && exit 0
+
+# Проверяем git checkout/switch (но не восстановление файлов)
+if ! echo "$COMMAND" | grep -qP 'git\s+(checkout|switch)\b'; then
+  exit 0
+fi
+
+# Разрешаем git checkout -- <file> (восстановление файлов)
+if echo "$COMMAND" | grep -qP 'git\s+(checkout|switch)\s+--\s'; then
+  exit 0
+fi
+
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
+
+# Проверяем, что мы в основном репозитории (не в worktree)
+GIT_DIR=$(git rev-parse --git-dir 2>/dev/null)
+COMMON_DIR=$(git rev-parse --git-common-dir 2>/dev/null)
+
+if [ "$(realpath "$GIT_DIR")" = "$(realpath "$COMMON_DIR")" ]; then
+  cat >&2 <<'EOF'
+BLOCKED: Переключение веток в основном репозитории запрещено.
+Используй EnterWorktree для работы на другой ветке.
+`git checkout -- <file>` для восстановления файлов по-прежнему доступен.
+EOF
+  exit 2
+fi
+
+exit 0

--- a/.claude/hooks/worktree-stop.sh
+++ b/.claude/hooks/worktree-stop.sh
@@ -9,6 +9,16 @@ if echo "$INPUT" | grep -qE '"stop_hook_active"\s*:\s*true'; then
   exit 0
 fi
 
+# Debounce: не блокируем повторно в течение 120 секунд
+DEBOUNCE_FILE="/tmp/claude-worktree-stop-${PPID}"
+if [ -f "$DEBOUNCE_FILE" ]; then
+  LAST=$(cat "$DEBOUNCE_FILE" 2>/dev/null || echo 0)
+  NOW=$(date +%s)
+  if [ $((NOW - LAST)) -lt 120 ]; then
+    exit 0
+  fi
+fi
+
 # Проверяем, что мы в git-репозитории
 git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
 
@@ -25,6 +35,9 @@ HAS_CHANGES=$(git status --porcelain 2>/dev/null | head -1)
 DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||')
 DEFAULT_BRANCH="${DEFAULT_BRANCH:-main}"
 AHEAD=$(git rev-list "$DEFAULT_BRANCH"..HEAD --count 2>/dev/null || echo "0")
+
+# Записываем время debounce
+date +%s > "$DEBOUNCE_FILE"
 
 # Блокируем stop — stderr покажется Claude
 cat >&2 <<EOF

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,37 @@
 {
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/require-worktree.sh",
+            "timeout": 5
+          }
+        ]
+      },
+      {
+        "matcher": "Agent",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/require-worktree-agent.sh",
+            "timeout": 5
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/block-branch-switch.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Edit|Write",
@@ -7,6 +39,43 @@
           {
             "type": "command",
             "command": ".claude/hooks/format-python.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/pr-monitor.sh",
+            "timeout": 5
+          }
+        ]
+      },
+      {
+        "matcher": "EnterWorktree",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/worktree-venv.sh",
+            "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": ".claude/hooks/worktree-setup.sh",
+            "timeout": 120,
+            "statusMessage": "Symlinking .env files and installing dev dependencies..."
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/worktree-stop.sh",
+            "timeout": 10
           }
         ]
       }


### PR DESCRIPTION
- Hooks were in settings.local.json (gitignored) — fresh clones had no worktree protection
- New `block-branch-switch.sh` prevents `git checkout/switch` on main in root repo
- 120s debounce in `worktree-stop.sh` prevents repeated blocking on quick retries

## Summary by Sourcery

Add safeguards and configuration updates to protect the main repository when switching branches or stopping worktrees.

Enhancements:
- Add a debounce mechanism to the worktree-stop hook to avoid repeated blocking within a short time window.
- Introduce a Bash hook that blocks git checkout/switch in the root repository while allowing file restoration via git checkout -- <file>.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added preventive controls for branch switching operations within the development environment
  * Enhanced automated cleanup with debounce mechanism to prevent redundant executions
  * Expanded development configuration with new hooks for environment setup, monitoring, and state management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->