### PR TITLE
fix(tests): adapt e2e tests for FastMCP 3.x response format

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,4 +1,5 @@
 import contextlib
+import json
 import os
 from collections.abc import AsyncGenerator
 from pathlib import Path
@@ -6,11 +7,34 @@ from typing import TYPE_CHECKING, Any
 
 import pytest
 from fastmcp import Client
+from pydantic import BaseModel
 
 from yazot.config import Settings
 from yazot.mcp_server import mcp
 from yazot.models import ZoteroItem
 from yazot.zotero_client import ZoteroClient
+
+
+def parse_tool_result[T: BaseModel](result: Any, model: type[T]) -> T:
+    """Parse FastMCP call_tool result into a Pydantic model.
+
+    FastMCP's Root objects lose nested model structure, so we re-parse
+    from raw JSON text using model_validate with alias support.
+    """
+    raw = json.loads(result.content[0].text)
+    return model.model_validate(raw)
+
+
+def parse_tool_result_list[T: BaseModel](result: Any, model: type[T]) -> list[T]:
+    """Parse FastMCP call_tool result into a list of Pydantic models."""
+    raw = json.loads(result.content[0].text)
+    return [model.model_validate(item) for item in raw]
+
+
+def parse_tool_result_dict(result: Any) -> dict[str, Any]:
+    """Parse FastMCP call_tool result into a plain dict."""
+    return json.loads(result.content[0].text)
+
 
 if TYPE_CHECKING:
     from tests.e2e.test_helpers import ZoteroTestDataManager

--- a/tests/e2e/test_collections.py
+++ b/tests/e2e/test_collections.py
@@ -3,7 +3,9 @@
 import pytest
 from fastmcp import Client
 
+from tests.e2e.conftest import parse_tool_result, parse_tool_result_dict
 from yazot.mcp_server import mcp
+from yazot.models import SearchCollectionResponse
 from yazot.zotero_client import ZoteroClient
 
 
@@ -25,7 +27,7 @@ class TestCollectionEndpoints:
                 "create_collection",
                 arguments={"name": collection_name},
             )
-            collection_data = result.data
+            collection_data = parse_tool_result_dict(result)
 
         # Verify collection was created
         assert collection_data is not None
@@ -52,7 +54,7 @@ class TestCollectionEndpoints:
                 "create_collection",
                 arguments={"name": parent_name},
             )
-            parent_data = parent_result.data
+            parent_data = parse_tool_result_dict(parent_result)
 
         # Create subcollection
         child_name = "Neural Networks"
@@ -64,7 +66,7 @@ class TestCollectionEndpoints:
                     "parent_collection_key": parent_data["key"],
                 },
             )
-            child_data = child_result.data
+            child_data = parse_tool_result_dict(child_result)
 
         # Verify subcollection was created
         assert child_data is not None
@@ -91,7 +93,7 @@ class TestCollectionEndpoints:
                 "create_collection",
                 arguments={"name": collection_name},
             )
-            collection_data = result.data
+            collection_data = parse_tool_result_dict(result)
 
         # Verify collection was created with correct name
         assert collection_data is not None
@@ -133,7 +135,7 @@ class TestAddItemsToCollection:
                 },
             )
 
-        assert "Added 1 item(s)" in str(result.data)
+        assert "Added 1 item(s)" in result.content[0].text
 
         # Verify item is in the collection
         async with Client(mcp) as client:
@@ -141,7 +143,7 @@ class TestAddItemsToCollection:
                 "get_collection_items",
                 arguments={"collection_key": collection_key},
             )
-            coll_items = coll_result.data
+            coll_items = parse_tool_result(coll_result, SearchCollectionResponse)
 
         found_keys = {item.key for item in coll_items.items}
         assert item_key in found_keys

--- a/tests/e2e/test_doi.py
+++ b/tests/e2e/test_doi.py
@@ -4,7 +4,9 @@ import pytest
 from fastmcp import Client
 from fastmcp.exceptions import ToolError
 
+from tests.e2e.conftest import parse_tool_result, parse_tool_result_dict
 from tests.e2e.test_helpers import ZoteroTestDataManager
+from yazot.models import ZoteroItem
 from yazot.zotero_client import ZoteroClient
 
 
@@ -25,12 +27,12 @@ class TestAddItemByDOI:
             "add_item_by_doi",
             arguments={"doi": doi},
         )
-        item = result.data
+        item = parse_tool_result(result, ZoteroItem)
 
         assert item is not None
         assert item.key
         assert item.data.title
-        assert doi == item.data.DOI
+        assert doi == item.data.doi
         assert len(item.data.creators) > 0
 
         await test_zotero_client.delete_item_by_key(item.key)
@@ -50,7 +52,7 @@ class TestAddItemByDOI:
             "add_item_by_doi",
             arguments={"doi": doi, "tags": tags},
         )
-        item = result.data
+        item = parse_tool_result(result, ZoteroItem)
 
         assert item is not None
         assert item.key
@@ -72,7 +74,7 @@ class TestAddItemByDOI:
             "create_collection",
             arguments={"name": "Test DOI Collection"},
         )
-        collection_data = coll_result.data
+        collection_data = parse_tool_result_dict(coll_result)
 
         doi = "10.1038/nature12373"
         item_result = await mcp_client.call_tool(
@@ -82,7 +84,7 @@ class TestAddItemByDOI:
                 "collection_key": collection_data["key"],
             },
         )
-        item = item_result.data
+        item = parse_tool_result(item_result, ZoteroItem)
 
         assert item is not None
         assert collection_data["key"] in item.data.collections
@@ -104,10 +106,10 @@ class TestAddItemByDOI:
             "add_item_by_doi",
             arguments={"doi": doi_url},
         )
-        item = result.data
+        item = parse_tool_result(result, ZoteroItem)
 
         assert item is not None
-        assert item.data.DOI == "10.1038/nature12373"
+        assert item.data.doi == "10.1038/nature12373"
 
         await test_zotero_client.delete_item_by_key(item.key)
 

--- a/tests/e2e/test_search.py
+++ b/tests/e2e/test_search.py
@@ -5,8 +5,10 @@ import json
 import pytest
 from fastmcp import Client
 
+from tests.e2e.conftest import parse_tool_result
 from yazot.chunker import ResponseChunker
 from yazot.mcp_server import mcp
+from yazot.models import SearchCollectionResponse
 from yazot.zotero_client import ZoteroClient
 
 
@@ -26,7 +28,7 @@ class TestSearchE2E:
 
         async with Client(mcp) as client:
             result = await client.call_tool("get_collection_items", arguments=request)
-            response = result.data
+            response = parse_tool_result(result, SearchCollectionResponse)
 
         # Verify response structure
         assert response.count == expected_count
@@ -53,7 +55,7 @@ class TestSearchE2E:
                 "get_collection_items",
                 arguments={"collection_key": collection_key},
             )
-            response = result.data
+            response = parse_tool_result(result, SearchCollectionResponse)
 
         # Check that fulltext field is populated (might be None)
         for item in response.items:
@@ -75,7 +77,7 @@ class TestSearchE2E:
                 "get_collection_items",
                 arguments={"collection_key": collection_key},
             )
-            response = result.data
+            response = parse_tool_result(result, SearchCollectionResponse)
 
         # Chunking should be triggered with small chunk size
         if response.has_more:
@@ -101,7 +103,7 @@ class TestSearchE2E:
 
         async with Client(mcp) as client:
             result = await client.call_tool("get_collection_items", arguments=request)
-            response = result.data
+            response = parse_tool_result(result, SearchCollectionResponse)
 
         # Estimate tokens for complete response
         chunker = ResponseChunker(max_tokens=18000)
@@ -145,7 +147,7 @@ class TestSearchE2E:
 
         async with Client(mcp) as client:
             result = await client.call_tool("search_articles", arguments=request)
-            response = result.data
+            response = parse_tool_result(result, SearchCollectionResponse)
 
         # Estimate tokens for complete response
         chunker = ResponseChunker(max_tokens=18000)
@@ -183,7 +185,7 @@ class TestSearchE2E:
             result = await client.call_tool(
                 "get_collection_items", arguments={"collection_key": collection_key}
             )
-            response = result.data
+            response = parse_tool_result(result, SearchCollectionResponse)
 
             # Check first chunk
             response_json = json.dumps(
@@ -207,7 +209,7 @@ class TestSearchE2E:
             while response.has_more:
                 chunk_id = response.chunk_id
                 result = await client.call_tool("get_next_chunk", arguments={"chunk_id": chunk_id})
-                response = result.data
+                response = parse_tool_result(result, SearchCollectionResponse)
 
                 # Check each chunk
                 response_json = json.dumps(
@@ -243,7 +245,7 @@ class TestSearchE2E:
 
         async with Client(mcp) as client:
             result = await client.call_tool("search_articles", arguments=request)
-            response = result.data
+            response = parse_tool_result(result, SearchCollectionResponse)
 
         # Should return results or empty list, not raise NotImplementedError
         assert isinstance(response.items, list)
@@ -260,11 +262,11 @@ class TestSearchE2E:
 
         async with Client(mcp) as client:
             result = await client.call_tool("search_articles", arguments=request)
-            response = result.data
+            response = parse_tool_result(result, SearchCollectionResponse)
 
         # All returned items should be journal articles
         for item in response.items:
-            assert item.data.itemType == "journalArticle"
+            assert item.data.item_type == "journalArticle"
 
     @pytest.mark.asyncio
     async def test_search_articles_combined_filters(
@@ -276,9 +278,9 @@ class TestSearchE2E:
 
         async with Client(mcp) as client:
             result = await client.call_tool("search_articles", arguments=request)
-            response = result.data
+            response = parse_tool_result(result, SearchCollectionResponse)
 
         # Should apply all filters
         for item in response.items:
-            assert item.data.itemType == "journalArticle"
+            assert item.data.item_type == "journalArticle"
             # Query is applied server-side, so we just verify type here

--- a/tests/e2e/test_subcollections.py
+++ b/tests/e2e/test_subcollections.py
@@ -3,7 +3,9 @@
 import pytest
 from fastmcp import Client
 
+from tests.e2e.conftest import parse_tool_result
 from yazot.mcp_server import mcp
+from yazot.models import SearchCollectionResponse
 from yazot.zotero_client import ZoteroClient
 
 
@@ -23,7 +25,7 @@ class TestSubcollections:
 
         async with Client(mcp) as client:
             result = await client.call_tool("get_collection_items", arguments=request)
-            response = result.data
+            response = parse_tool_result(result, SearchCollectionResponse)
 
         # Should return only items from main collection
         assert response.count == expected_count
@@ -42,7 +44,7 @@ class TestSubcollections:
 
         async with Client(mcp) as client:
             result = await client.call_tool("get_collection_items", arguments=request)
-            response = result.data
+            response = parse_tool_result(result, SearchCollectionResponse)
 
         # Should return only items from parent collection
         assert response.count == parent_count
@@ -61,7 +63,7 @@ class TestSubcollections:
 
         async with Client(mcp) as client:
             result = await client.call_tool("get_collection_items", arguments=request)
-            response = result.data
+            response = parse_tool_result(result, SearchCollectionResponse)
 
         # Should return items from parent + all subcollections
         assert response.count == total_count
@@ -84,7 +86,7 @@ class TestSubcollections:
 
         async with Client(mcp) as client:
             result = await client.call_tool("get_collection_items", arguments=request)
-            response = result.data
+            response = parse_tool_result(result, SearchCollectionResponse)
 
         # Total count should be sum of all levels
         expected_total = sum(counts.values())
@@ -104,7 +106,7 @@ class TestSubcollections:
 
         async with Client(mcp) as client:
             result = await client.call_tool("get_collection_items", arguments=request)
-            response = result.data
+            response = parse_tool_result(result, SearchCollectionResponse)
 
         # Should return only unique items
         assert response.count == unique_count
@@ -127,7 +129,7 @@ class TestSubcollections:
 
         async with Client(mcp) as client:
             result = await client.call_tool("get_collection_items", arguments=request)
-            response = result.data
+            response = parse_tool_result(result, SearchCollectionResponse)
 
         # Should return only items from parent (subcollections are empty)
         assert response.count == expected_count
@@ -148,7 +150,7 @@ class TestSubcollections:
                 "get_collection_items",
                 arguments={"collection_key": parent_key, "include_subcollections": True},
             )
-            response = result.data
+            response = parse_tool_result(result, SearchCollectionResponse)
 
             # With small chunk size, chunking should be triggered
             if response.has_more:
@@ -164,7 +166,7 @@ class TestSubcollections:
                     result = await client.call_tool(
                         "get_next_chunk", arguments={"chunk_id": chunk_id}
                     )
-                    response = result.data
+                    response = parse_tool_result(result, SearchCollectionResponse)
                     all_items.extend(response.items)
                     chunk_id = response.chunk_id
 

--- a/tests/e2e/test_tags.py
+++ b/tests/e2e/test_tags.py
@@ -3,8 +3,9 @@
 import pytest
 from fastmcp import Client
 
+from tests.e2e.conftest import parse_tool_result
 from yazot.mcp_server import mcp
-from yazot.models import ZoteroItem
+from yazot.models import Note, SearchCollectionResponse, ZoteroItem
 from yazot.zotero_client import ZoteroClient
 
 
@@ -24,7 +25,7 @@ class TestTagsE2E:
             result = await client.call_tool(
                 "get_collection_items", arguments={"collection_key": collection_key_items_with_tags}
             )
-            test_items = result.data.items
+            test_items = parse_tool_result(result, SearchCollectionResponse).items
 
         # Find our test items in the response
         test_item_keys = {item.key for item in test_items}
@@ -59,10 +60,8 @@ class TestTagsE2E:
         search_tag = "manual-tag-1"
 
         async with Client(mcp) as client:
-            result = await client.call_tool(
-                "search_articles", arguments={"tags": [search_tag]}
-            )
-            response = result.data
+            result = await client.call_tool("search_articles", arguments={"tags": [search_tag]})
+            response = parse_tool_result(result, SearchCollectionResponse)
 
         # Should find at least the item with this tag
         assert response.count > 0
@@ -84,10 +83,8 @@ class TestTagsE2E:
         search_tags = ["manual-mixed", "auto-mixed"]
 
         async with Client(mcp) as client:
-            result = await client.call_tool(
-                "search_articles", arguments={"tags": search_tags}
-            )
-            response = result.data
+            result = await client.call_tool("search_articles", arguments={"tags": search_tags})
+            response = parse_tool_result(result, SearchCollectionResponse)
 
         # Should find at least one item with both tags
         assert response.count > 0
@@ -113,7 +110,7 @@ class TestTagsE2E:
                 "get_collection_items",
                 arguments={"collection_key": collection_key_items_with_tags},
             )
-            item_key = items_result.data.items[0].key
+            item_key = parse_tool_result(items_result, SearchCollectionResponse).items[0].key
 
             result = await client.call_tool(
                 "create_note_for_item",
@@ -124,7 +121,7 @@ class TestTagsE2E:
                     "tags": note_tags,
                 },
             )
-            note = result.data
+            note = parse_tool_result(result, Note)
 
         # Verify note was created with tags
         assert note is not None
@@ -143,7 +140,7 @@ class TestTagsE2E:
             result = await client.call_tool(
                 "get_collection_items", arguments={"collection_key": collection_key_items_with_tags}
             )
-            response = result.data
+            response = parse_tool_result(result, SearchCollectionResponse)
 
         for item in response.items:
             # Verify tags property returns strings

--- a/tests/e2e/test_web_api.py
+++ b/tests/e2e/test_web_api.py
@@ -8,7 +8,9 @@ import pytest
 from fastmcp import Client
 from fastmcp.exceptions import ToolError
 
+from tests.e2e.conftest import parse_tool_result, parse_tool_result_dict, parse_tool_result_list
 from yazot.mcp_server import mcp
+from yazot.models import Note, SearchCollectionResponse, ZoteroItem
 from yazot.zotero_client import ZoteroClient
 
 if TYPE_CHECKING:
@@ -41,7 +43,7 @@ class TestWebApiWrite:
                 "search_articles",
                 arguments={"query": title_fragment},
             )
-            response = result.data
+            response = parse_tool_result(result, SearchCollectionResponse)
 
         assert isinstance(response.items, list)
         assert response.count >= 0
@@ -69,7 +71,7 @@ class TestWebApiWrite:
                 "get_collection_items",
                 arguments={"collection_key": collection_key},
             )
-            response = result.data
+            response = parse_tool_result(result, SearchCollectionResponse)
 
         assert response.count == 5
         assert isinstance(response.items, list)
@@ -98,7 +100,7 @@ class TestWebApiWrite:
                     "content": "Content for live integration test.",
                 },
             )
-            note = note_result.data
+            note = parse_tool_result(note_result, Note)
 
         assert note.key
         assert note.parent_key == item_key
@@ -108,7 +110,7 @@ class TestWebApiWrite:
                 "get_item_notes",
                 arguments={"item_key": item_key},
             )
-            notes = notes_result.data
+            notes = parse_tool_result_list(notes_result, Note)
 
         note_keys = [n.key for n in notes]
         assert note.key in note_keys
@@ -132,7 +134,7 @@ class TestWebApiWrite:
                     "create_collection",
                     arguments={"name": "Live Hierarchy Parent"},
                 )
-                parent_data = parent_result.data
+                parent_data = parse_tool_result_dict(parent_result)
                 assert parent_data["key"]
                 parent_key = parent_data["key"]
 
@@ -144,7 +146,7 @@ class TestWebApiWrite:
                         "parent_collection_key": parent_key,
                     },
                 )
-                sub_data = sub_result.data
+                sub_data = parse_tool_result_dict(sub_result)
                 assert sub_data["key"]
                 sub_key = sub_data["key"]
 
@@ -159,7 +161,7 @@ class TestWebApiWrite:
                         "include_subcollections": True,
                     },
                 )
-                response = result.data
+                response = parse_tool_result(result, SearchCollectionResponse)
 
             assert isinstance(response.items, list)
             returned_keys = {item.key for item in response.items}
@@ -189,11 +191,11 @@ class TestWebApiWrite:
                 "search_articles",
                 arguments={"item_type": "journalArticle"},
             )
-            response = result.data
+            response = parse_tool_result(result, SearchCollectionResponse)
 
         assert isinstance(response.items, list)
         for item in response.items:
-            assert item.data.itemType == "journalArticle"
+            assert item.data.item_type == "journalArticle"
 
 
 _DOI = "10.1038/nature12373"
@@ -216,11 +218,11 @@ class TestDoiSearchAndCreate:
                     "add_item_by_doi",
                     arguments={"doi": _DOI},
                 )
-                item = result.data
+                item = parse_tool_result(result, ZoteroItem)
 
             assert item.key
             assert item.data.title
-            assert item.data.DOI == _DOI
+            assert item.data.doi == _DOI
             assert len(item.data.creators) > 0
 
         finally:
@@ -244,7 +246,7 @@ class TestDoiSearchAndCreate:
                     "create_collection",
                     arguments={"name": "DOI Test Collection"},
                 )
-                collection_data = coll_result.data
+                collection_data = parse_tool_result_dict(coll_result)
                 assert collection_data["key"]
                 collection_key = collection_data["key"]
 
@@ -252,7 +254,7 @@ class TestDoiSearchAndCreate:
                     "add_item_by_doi",
                     arguments={"doi": _DOI, "collection_key": collection_key},
                 )
-                item = item_result.data
+                item = parse_tool_result(item_result, ZoteroItem)
                 item_key = item.key
 
             assert collection_key in item.data.collections
@@ -281,7 +283,7 @@ class TestDoiSearchAndCreate:
                     "add_item_by_doi",
                     arguments={"doi": _DOI, "tags": tags},
                 )
-                item = result.data
+                item = parse_tool_result(result, ZoteroItem)
 
             item_tag_names = [t.tag for t in item.data.tags]
             for tag in tags:
@@ -307,14 +309,14 @@ class TestDoiSearchAndCreate:
                     "add_item_by_doi",
                     arguments={"doi": _DOI},
                 )
-                item = result.data
+                item = parse_tool_result(result, ZoteroItem)
 
             async with Client(mcp) as client:
                 search_result = await client.call_tool(
                     "search_articles",
                     arguments={"query": "Nanometre-scale thermometry"},
                 )
-                response = search_result.data
+                response = parse_tool_result(search_result, SearchCollectionResponse)
 
             assert isinstance(response.items, list)
             found_keys = {i.key for i in response.items}


### PR DESCRIPTION
- FastMCP 3.x returns JSON in `result.content[0].text` instead of typed models in `result.data` — add `parse_tool_result` helpers to conftest and update all e2e tests
- Fix field access to use Python attribute names (`doi`, `item_type`) instead of Zotero API aliases (`DOI`, `itemType`)

Note: pre-commit mypy hook is broken on main too (`mirrors-mypy` missing `pydantic` in `additional_dependencies`) — separate issue.

## Summary by Sourcery

Update e2e tests to work with FastMCP 3.x JSON response format and align assertions with current Zotero model field names.

Tests:
- Adjust e2e tests to parse FastMCP 3.x tool responses from raw JSON content instead of relying on typed result.data.
- Update test expectations to use Zotero model attribute names (e.g., doi, item_type) instead of legacy Zotero API aliases.
- Add shared helpers in the e2e test conftest for parsing tool results into Pydantic models, lists, and plain dicts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added structured response parsing utilities for E2E tests, updating all test modules (collections, search, DOI, tags, web API) to parse FastMCP tool outputs using typed Pydantic models instead of raw data access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->