### PR TITLE
fix(ci): replace black with ruff format in lint step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
           cache-dependency-glob: uv.lock
       - run: uv sync --group dev
       - run: uv run ruff check yazot/ tests/
-      - run: uv run black --check yazot/ tests/
+      - run: uv run ruff format --check yazot/ tests/
       - run: uv run mypy yazot/
 
   unit-tests:


### PR DESCRIPTION
- black was removed from dependencies in #27 but ci.yml still referenced it, causing every CI run to fail with `Failed to spawn: black`

## Summary by Sourcery

CI:
- Replace Black formatting check with Ruff format check in the CI lint job to align with removed Black dependency and restore passing runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code formatting verification in CI pipeline to use a different formatting tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->