### PR TITLE
fix: use local mypy hook to run in project venv

### DIFF
--- a/.claude/rules/testing-pydantic-settings.md
+++ b/.claude/rules/testing-pydantic-settings.md
@@ -1,6 +1,10 @@
 # Testing with pydantic-settings
 
-When clearing env vars in tests, use `monkeypatch.setenv("VAR", "")` instead of
-`monkeypatch.delenv("VAR")` — pydantic-settings falls back to `.env` file values
-when the env var is missing from `os.environ`, so `delenv` doesn't actually clear
-the value from Settings' perspective.
+`monkeypatch.delenv("VAR")` does NOT fully clear the value — pydantic-settings
+falls back to `.env` file values when the env var is missing from `os.environ`.
+
+Choose the right approach by field type:
+- **str / Optional[str]**: `monkeypatch.setenv("VAR", "")` — sets to empty string
+- **bool**: `monkeypatch.setenv("VAR", "false")` — pydantic coerces correctly
+- **int**: `monkeypatch.delenv("VAR", raising=False)` — let pydantic use the field default
+- When the field has no default and you need to disable it: set a valid sentinel value for that type

--- a/.claude/rules/testing-pydantic-settings.md
+++ b/.claude/rules/testing-pydantic-settings.md
@@ -1,0 +1,6 @@
+# Testing with pydantic-settings
+
+When clearing env vars in tests, use `monkeypatch.setenv("VAR", "")` instead of
+`monkeypatch.delenv("VAR")` — pydantic-settings falls back to `.env` file values
+when the env var is missing from `os.environ`, so `delenv` doesn't actually clear
+the value from Settings' perspective.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,15 +10,18 @@ repos:
       - id: check-added-large-files
       - id: check-merge-conflict
 
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.6
-    hooks:
-      - id: ruff
-        args: [--fix, --exit-non-zero-on-fix]
-      - id: ruff-format
-
   - repo: local
     hooks:
+      - id: ruff
+        name: ruff
+        entry: uv run ruff check --fix --exit-non-zero-on-fix
+        language: system
+        types: [python]
+      - id: ruff-format
+        name: ruff-format
+        entry: uv run ruff format
+        language: system
+        types: [python]
       - id: mypy
         name: mypy
         entry: uv run mypy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,6 @@ repos:
         name: mypy
         entry: uv run mypy
         language: system
-        types: [python]
+        files: ^yazot/
         pass_filenames: false
         args: [yazot/]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,14 +17,12 @@ repos:
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
 
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.17.1
+  - repo: local
     hooks:
       - id: mypy
-        args: [--ignore-missing-imports]
-        files: ^yazot/
-        additional_dependencies:
-          - pydantic>=2.0.0
-          - pydantic-settings>=2.0.0
-          - fastmcp>=2.0.0
-          - types-beautifulsoup4
+        name: mypy
+        entry: uv run mypy
+        language: system
+        types: [python]
+        pass_filenames: false
+        args: [yazot/]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,9 @@ Configuration via `.env` (pydantic-settings). Two modes:
 
 For tests: `.env.test` (auto-loaded via `conftest.py`)
 
+**Important:** pydantic-settings loads `.env` internally but does NOT export values to `os.environ`.
+Tests use `load_dotenv(".env.test", override=True)` in `conftest.py` to export test config to `os.environ`.
+
 ## Conventions
 
 - All models — Pydantic v2 BaseModel (not dicts)

--- a/tests/e2e/test_fulltext.py
+++ b/tests/e2e/test_fulltext.py
@@ -145,9 +145,9 @@ class TestMCPFulltextEndpoint:
         )
 
         response_tokens = len(response_json) // 4
-        assert (
-            response_tokens < 25000
-        ), f"Response exceeds MCP token limit: {response_tokens} tokens"
+        assert response_tokens < 25000, (
+            f"Response exceeds MCP token limit: {response_tokens} tokens"
+        )
 
     @pytest.mark.asyncio
     async def test_get_item_fulltext_chunking_workflow(
@@ -198,8 +198,8 @@ class TestMCPFulltextEndpoint:
                     default=str,
                 )
                 chunk_tokens = len(chunk_json) // 4
-                assert (
-                    chunk_tokens < 25000
-                ), f"Chunk {chunk_count} exceeds limit: {chunk_tokens} tokens"
+                assert chunk_tokens < 25000, (
+                    f"Chunk {chunk_count} exceeds limit: {chunk_tokens} tokens"
+                )
 
             assert len(all_content) > 0

--- a/tests/e2e/test_search.py
+++ b/tests/e2e/test_search.py
@@ -166,9 +166,9 @@ class TestSearchE2E:
 
         response_tokens = len(response_json) // 4
 
-        assert (
-            response_tokens < 25000
-        ), f"search_articles response exceeds MCP token limit: {response_tokens} tokens"
+        assert response_tokens < 25000, (
+            f"search_articles response exceeds MCP token limit: {response_tokens} tokens"
+        )
 
     @pytest.mark.asyncio
     async def test_chunked_response_workflow_stays_under_limit(
@@ -226,9 +226,9 @@ class TestSearchE2E:
                 )
                 chunk_tokens = len(response_json) // 4
 
-                assert (
-                    chunk_tokens < 25000
-                ), f"Chunk {chunk_count + 1} exceeds limit: {chunk_tokens} tokens"
+                assert chunk_tokens < 25000, (
+                    f"Chunk {chunk_count + 1} exceeds limit: {chunk_tokens} tokens"
+                )
 
                 chunk_count += 1
 

--- a/tests/live/zotero_instance.py
+++ b/tests/live/zotero_instance.py
@@ -214,7 +214,7 @@ class ZoteroInstance:
         if not self._wait_for_ready():
             self.stop()
             raise RuntimeError(
-                f"Zotero failed to start on port {self._port} " f"within {self._startup_timeout}s"
+                f"Zotero failed to start on port {self._port} within {self._startup_timeout}s"
             )
 
         logger.info(
@@ -390,6 +390,6 @@ def detect_xvfb_needed() -> bool:
         return False
     if not shutil.which("xvfb-run"):
         raise RuntimeError(
-            "No DISPLAY set and xvfb-run not found. " "Install xvfb or run with a display server."
+            "No DISPLAY set and xvfb-run not found. Install xvfb or run with a display server."
         )
     return True

--- a/tests/unit/test_response_chunker.py
+++ b/tests/unit/test_response_chunker.py
@@ -314,9 +314,9 @@ class TestResponseChunker:
         first_chunk_tokens = chunker.estimate_response_tokens(response.items, include_metadata=True)
 
         # First chunk should be under MCP limit
-        assert (
-            first_chunk_tokens < chunker.MCP_TOKEN_LIMIT
-        ), f"First chunk has {first_chunk_tokens} tokens, exceeds MCP limit of {chunker.MCP_TOKEN_LIMIT}"
+        assert first_chunk_tokens < chunker.MCP_TOKEN_LIMIT, (
+            f"First chunk has {first_chunk_tokens} tokens, exceeds MCP limit of {chunker.MCP_TOKEN_LIMIT}"
+        )
 
         # Check all subsequent chunks
         chunk_id = response.chunk_id
@@ -326,9 +326,9 @@ class TestResponseChunker:
                 next_response.items, include_metadata=True
             )
 
-            assert (
-                chunk_tokens < chunker.MCP_TOKEN_LIMIT
-            ), f"Chunk {next_response.current_chunk} has {chunk_tokens} tokens, exceeds MCP limit"
+            assert chunk_tokens < chunker.MCP_TOKEN_LIMIT, (
+                f"Chunk {next_response.current_chunk} has {chunk_tokens} tokens, exceeds MCP limit"
+            )
 
             chunk_id = next_response.chunk_id if next_response.has_more else None
 

--- a/tests/unit/test_server_startup.py
+++ b/tests/unit/test_server_startup.py
@@ -44,9 +44,9 @@ class TestMCPServerStartup:
         ]
 
         for expected_resource in expected_resources:
-            assert (
-                expected_resource in resource_uris
-            ), f"Resource {expected_resource} not registered"
+            assert expected_resource in resource_uris, (
+                f"Resource {expected_resource} not registered"
+            )
 
     async def test_mcp_server_metadata(self) -> None:
         """Test that server has correct metadata."""

--- a/yazot/zotero_client.py
+++ b/yazot/zotero_client.py
@@ -653,7 +653,7 @@ class ZoteroClient(ZoteroClientProtocol):
             )
         except zotero_errors.UnsupportedParamsError as e:
             raise ZoteroError(
-                f"Invalid search parameters: {e}. " "Hint: check query, item_type, and tag values."
+                f"Invalid search parameters: {e}. Hint: check query, item_type, and tag values."
             ) from e
         except zotero_errors.PyZoteroError as e:
             raise ZoteroError(
@@ -805,7 +805,7 @@ class ZoteroClient(ZoteroClientProtocol):
             ) from e
         except Exception as e:
             raise ZoteroError(
-                f"Unexpected error attaching PDF to item '{item_key}': " f"{type(e).__name__}: {e}"
+                f"Unexpected error attaching PDF to item '{item_key}': {type(e).__name__}: {e}"
             ) from e
 
     @webonly


### PR DESCRIPTION
- Replace mirrors-mypy sandbox with local `uv run mypy` — stricter checking (no `--ignore-missing-imports`), no manual `additional_dependencies` duplication
- Document pydantic-settings `.env` loading pitfall for tests
- Supersedes posthoc-improvements branch changes

## Summary by Sourcery

Replace the external mypy pre-commit hook with a local project-venv mypy invocation and document pydantic-settings testing behavior.

Build:
- Switch mypy pre-commit hook from mirrors-mypy to a local hook running `uv run mypy` without extra dependency duplication.

Documentation:
- Document how pydantic-settings loads `.env` files in tests and how test configuration is exported to `os.environ`.
- Add internal testing guidelines for clearing environment variables when using pydantic-settings.

Chores:
- Add internal rules file describing correct use of pydantic-settings in tests, including env var clearing semantics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for testing with pydantic-settings and pytest monkeypatch, and clarified how test configuration is exported to environment variables.

* **Chores**
  * Updated the mypy pre-commit hook to use a local/system invocation instead of the previous upstream hook configuration.

* **Bug Fixes**
  * Improved wording of several runtime/error messages to remove spacing/artifact issues and present clearer, single-sentence messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->