### PR TITLE
feat: add Zotero 9 schema fields

### DIFF
--- a/yazot/crossref_client.py
+++ b/yazot/crossref_client.py
@@ -284,7 +284,7 @@ class CrossrefClient:
             "book": "book",
             "proceedings-article": "conferencePaper",
             "report": "report",
-            "dataset": "document",
+            "dataset": "dataset",
             "posted-content": "preprint",
         }
         return type_mapping.get(crossref_type, "journalArticle")

--- a/yazot/models.py
+++ b/yazot/models.py
@@ -109,6 +109,9 @@ class ZoteroItemData(BaseModel):
     url: str | None = None
     isbn: str | None = Field(None, alias="ISBN")
     issn: str | None = Field(None, alias="ISSN")
+    pmid: str | None = Field(None, alias="PMID")
+    pmcid: str | None = Field(None, alias="PMCID")
+    citation_key: str | None = Field(None, alias="citationKey")
 
     # Publication fields (journalArticle, conferencePaper)
     publication_title: str | None = Field(None, alias="publicationTitle")
@@ -121,6 +124,10 @@ class ZoteroItemData(BaseModel):
 
     # Book fields
     publisher: str | None = None
+    place: str | None = None
+    original_date: str | None = Field(None, alias="originalDate")
+    original_publisher: str | None = Field(None, alias="originalPublisher")
+    original_place: str | None = Field(None, alias="originalPlace")
 
     # Note fields
     note: str | None = None
@@ -292,6 +299,9 @@ class ItemCreate(BaseModel):
     url: str | None = None
     isbn: str | None = Field(None, alias="ISBN")
     issn: str | None = Field(None, alias="ISSN")
+    pmid: str | None = Field(None, alias="PMID")
+    pmcid: str | None = Field(None, alias="PMCID")
+    citation_key: str | None = Field(None, alias="citationKey")
 
     # Publication fields (journalArticle, conferencePaper)
     publication_title: str | None = Field(None, alias="publicationTitle")
@@ -304,6 +314,10 @@ class ItemCreate(BaseModel):
 
     # Book fields
     publisher: str | None = None
+    place: str | None = None
+    original_date: str | None = Field(None, alias="originalDate")
+    original_publisher: str | None = Field(None, alias="originalPublisher")
+    original_place: str | None = Field(None, alias="originalPlace")
 
     # Note fields
     note: str | None = None
@@ -333,6 +347,9 @@ class ItemUpdate(BaseModel):
     url: str | None = None
     isbn: str | None = Field(None, alias="ISBN")
     issn: str | None = Field(None, alias="ISSN")
+    pmid: str | None = Field(None, alias="PMID")
+    pmcid: str | None = Field(None, alias="PMCID")
+    citation_key: str | None = Field(None, alias="citationKey")
 
     # Publication fields
     publication_title: str | None = Field(None, alias="publicationTitle")
@@ -345,6 +362,10 @@ class ItemUpdate(BaseModel):
 
     # Book fields
     publisher: str | None = None
+    place: str | None = None
+    original_date: str | None = Field(None, alias="originalDate")
+    original_publisher: str | None = Field(None, alias="originalPublisher")
+    original_place: str | None = Field(None, alias="originalPlace")
 
     # Note fields
     note: str | None = None


### PR DESCRIPTION
## Summary
- Add PMID, PMCID, citationKey, place, originalDate, originalPublisher, originalPlace fields to ZoteroItemData, ItemCreate, ItemUpdate
- Fix Crossref `dataset` type mapping to native Zotero `dataset` instead of `document`
- All fields are Optional with None default — fully backward-compatible with Zotero 7/8

## Summary by Sourcery

Extend Zotero item models with new optional metadata fields and correct Crossref dataset type mapping.

New Features:
- Add PMID, PMCID, citation key, place, original date, original publisher, and original place fields to ZoteroItemData, ItemCreate, and ItemUpdate models.

Bug Fixes:
- Map Crossref dataset type to Zotero's native dataset type instead of document.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for additional identifier fields: PMID, PMCID, and citation key
  * Added optional book metadata fields: place, original date, original publisher, and original place

* **Bug Fixes**
  * Fixed dataset type mapping for improved accuracy in data conversions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->