### PR TITLE
feat: add update_item_tags MCP tool

### DIFF
--- a/tests/e2e/test_update_tags.py
+++ b/tests/e2e/test_update_tags.py
@@ -1,0 +1,278 @@
+"""E2E tests for update_item_tags MCP tool."""
+
+from typing import TYPE_CHECKING
+
+import pytest
+from fastmcp import Client
+from fastmcp.exceptions import ToolError
+
+from tests.e2e.conftest import parse_tool_result_dict
+from yazot.mcp_server import mcp
+from yazot.zotero_client import ZoteroClient
+
+if TYPE_CHECKING:
+    from tests.e2e.test_helpers import ZoteroTestDataManager
+
+
+class TestUpdateItemTagsAdd:
+    """Tests for mode='add' (default)."""
+
+    @pytest.mark.asyncio
+    async def test_add_new_tags(
+        self,
+        test_data_manager: "ZoteroTestDataManager",
+        test_zotero_client: ZoteroClient,
+    ) -> None:
+        """Adding new tags to an item with no tags."""
+        items = await test_data_manager.create_test_items(1)
+        item_key = items[0].key
+
+        async with Client(mcp) as client:
+            result = await client.call_tool(
+                "update_item_tags",
+                arguments={"item_key": item_key, "tags": ["new-tag-1", "new-tag-2"]},
+            )
+        data = parse_tool_result_dict(result)
+
+        assert data["changed"] is True
+        assert data["mode"] == "add"
+        assert "new-tag-1" in data["tags_after"]
+        assert "new-tag-2" in data["tags_after"]
+
+        # Verify via direct API
+        updated = await test_zotero_client.get_item(item_key)
+        assert "new-tag-1" in updated.tags
+        assert "new-tag-2" in updated.tags
+
+    @pytest.mark.asyncio
+    async def test_add_duplicate_tags_no_change(
+        self,
+        test_data_manager: "ZoteroTestDataManager",
+    ) -> None:
+        """Adding tags that already exist results in changed=False."""
+        items = await test_data_manager.create_test_items(1)
+        item_key = items[0].key
+
+        async with Client(mcp) as client:
+            # First add
+            await client.call_tool(
+                "update_item_tags",
+                arguments={"item_key": item_key, "tags": ["existing"]},
+            )
+            # Second add — same tag
+            result = await client.call_tool(
+                "update_item_tags",
+                arguments={"item_key": item_key, "tags": ["existing"]},
+            )
+        data = parse_tool_result_dict(result)
+
+        assert data["changed"] is False
+        assert data["tags_before"] == data["tags_after"]
+
+    @pytest.mark.asyncio
+    async def test_add_preserves_existing_tag_types(
+        self,
+        collection_key_items_with_tags: str,
+        test_zotero_client: ZoteroClient,
+    ) -> None:
+        """Adding new tags preserves type of existing auto-tags (type=0)."""
+        # Get an item with auto tags (type=0)
+        async with Client(mcp) as client:
+            from tests.e2e.conftest import parse_tool_result
+            from yazot.models import SearchCollectionResponse
+
+            items_result = await client.call_tool(
+                "get_collection_items",
+                arguments={"collection_key": collection_key_items_with_tags},
+            )
+            items = parse_tool_result(items_result, SearchCollectionResponse).items
+
+        # Find item with auto tags
+        auto_item = next(
+            (i for i in items if any(t.type == 0 for t in i.data.tags)),
+            None,
+        )
+        assert auto_item is not None, "Test fixture should have items with auto-tags"
+
+        async with Client(mcp) as client:
+            result = await client.call_tool(
+                "update_item_tags",
+                arguments={"item_key": auto_item.key, "tags": ["extra-tag"]},
+            )
+        data = parse_tool_result_dict(result)
+        assert data["changed"] is True
+
+        # Verify existing auto-tags preserved their type via raw API
+        raw = await test_zotero_client.get_raw_item(auto_item.key)
+        raw_tags = raw["data"]["tags"]
+        auto_tags = [t for t in raw_tags if t["type"] == 0]
+        assert len(auto_tags) > 0, "Auto-tags should be preserved with type=0"
+
+    @pytest.mark.asyncio
+    async def test_add_empty_list_is_noop(
+        self,
+        test_data_manager: "ZoteroTestDataManager",
+    ) -> None:
+        """Adding empty list returns changed=False."""
+        items = await test_data_manager.create_test_items(1)
+        item_key = items[0].key
+
+        async with Client(mcp) as client:
+            result = await client.call_tool(
+                "update_item_tags",
+                arguments={"item_key": item_key, "tags": []},
+            )
+        data = parse_tool_result_dict(result)
+
+        assert data["changed"] is False
+
+    @pytest.mark.asyncio
+    async def test_default_mode_is_add(
+        self,
+        test_data_manager: "ZoteroTestDataManager",
+    ) -> None:
+        """Calling without mode uses 'add'."""
+        items = await test_data_manager.create_test_items(1)
+        item_key = items[0].key
+
+        async with Client(mcp) as client:
+            result = await client.call_tool(
+                "update_item_tags",
+                arguments={"item_key": item_key, "tags": ["default-mode-tag"]},
+            )
+        data = parse_tool_result_dict(result)
+
+        assert data["mode"] == "add"
+        assert data["changed"] is True
+
+
+class TestUpdateItemTagsRemove:
+    """Tests for mode='remove'."""
+
+    @pytest.mark.asyncio
+    async def test_remove_existing_tags(
+        self,
+        test_data_manager: "ZoteroTestDataManager",
+        test_zotero_client: ZoteroClient,
+    ) -> None:
+        """Removing existing tags removes them."""
+        items = await test_data_manager.create_test_items(1)
+        item_key = items[0].key
+
+        async with Client(mcp) as client:
+            # Setup: add tags
+            await client.call_tool(
+                "update_item_tags",
+                arguments={"item_key": item_key, "tags": ["keep-me", "remove-me"]},
+            )
+            # Remove one tag
+            result = await client.call_tool(
+                "update_item_tags",
+                arguments={"item_key": item_key, "tags": ["remove-me"], "mode": "remove"},
+            )
+        data = parse_tool_result_dict(result)
+
+        assert data["changed"] is True
+        assert "remove-me" not in data["tags_after"]
+        assert "keep-me" in data["tags_after"]
+
+        # Verify via direct API
+        updated = await test_zotero_client.get_item(item_key)
+        assert "remove-me" not in updated.tags
+        assert "keep-me" in updated.tags
+
+    @pytest.mark.asyncio
+    async def test_remove_nonexistent_tags_no_change(
+        self,
+        test_data_manager: "ZoteroTestDataManager",
+    ) -> None:
+        """Removing tags that don't exist returns changed=False."""
+        items = await test_data_manager.create_test_items(1)
+        item_key = items[0].key
+
+        async with Client(mcp) as client:
+            result = await client.call_tool(
+                "update_item_tags",
+                arguments={"item_key": item_key, "tags": ["nonexistent"], "mode": "remove"},
+            )
+        data = parse_tool_result_dict(result)
+
+        assert data["changed"] is False
+
+
+class TestUpdateItemTagsReplace:
+    """Tests for mode='replace'."""
+
+    @pytest.mark.asyncio
+    async def test_replace_all_tags(
+        self,
+        test_data_manager: "ZoteroTestDataManager",
+        test_zotero_client: ZoteroClient,
+    ) -> None:
+        """Replace mode sets exactly the specified tags."""
+        items = await test_data_manager.create_test_items(1)
+        item_key = items[0].key
+
+        async with Client(mcp) as client:
+            # Setup: add tags
+            await client.call_tool(
+                "update_item_tags",
+                arguments={"item_key": item_key, "tags": ["old-tag-1", "old-tag-2"]},
+            )
+            # Replace
+            result = await client.call_tool(
+                "update_item_tags",
+                arguments={"item_key": item_key, "tags": ["new-tag"], "mode": "replace"},
+            )
+        data = parse_tool_result_dict(result)
+
+        assert data["changed"] is True
+        assert data["tags_after"] == ["new-tag"]
+
+        # Verify via direct API
+        updated = await test_zotero_client.get_item(item_key)
+        assert updated.tags == ["new-tag"]
+
+    @pytest.mark.asyncio
+    async def test_replace_with_empty_clears_tags(
+        self,
+        test_data_manager: "ZoteroTestDataManager",
+        test_zotero_client: ZoteroClient,
+    ) -> None:
+        """Replace with empty list clears all tags."""
+        items = await test_data_manager.create_test_items(1)
+        item_key = items[0].key
+
+        async with Client(mcp) as client:
+            # Setup: add tags
+            await client.call_tool(
+                "update_item_tags",
+                arguments={"item_key": item_key, "tags": ["some-tag"]},
+            )
+            # Clear
+            result = await client.call_tool(
+                "update_item_tags",
+                arguments={"item_key": item_key, "tags": [], "mode": "replace"},
+            )
+        data = parse_tool_result_dict(result)
+
+        assert data["changed"] is True
+        assert data["tags_after"] == []
+
+        # Verify via direct API
+        updated = await test_zotero_client.get_item(item_key)
+        assert updated.tags == []
+
+
+class TestUpdateItemTagsErrors:
+    """Error handling tests."""
+
+    @pytest.mark.asyncio
+    async def test_nonexistent_item_raises_error(self) -> None:
+        """Non-existent item_key raises error."""
+        async with Client(mcp) as client:
+            with pytest.raises(ToolError):
+                await client.call_tool(
+                    "update_item_tags",
+                    arguments={"item_key": "NONEXISTENT999", "tags": ["x"]},
+                )

--- a/tests/e2e/test_update_tags.py
+++ b/tests/e2e/test_update_tags.py
@@ -75,7 +75,7 @@ class TestUpdateItemTagsAdd:
         collection_key_items_with_tags: str,
         test_zotero_client: ZoteroClient,
     ) -> None:
-        """Adding new tags preserves type of existing auto-tags (type=0)."""
+        """Adding new tags preserves type of existing auto-tags (type=0) and creates new with type=1."""
         # Get an item with auto tags (type=0)
         async with Client(mcp) as client:
             from tests.e2e.conftest import parse_tool_result
@@ -107,6 +107,11 @@ class TestUpdateItemTagsAdd:
         raw_tags = raw["data"]["tags"]
         auto_tags = [t for t in raw_tags if t["type"] == 0]
         assert len(auto_tags) > 0, "Auto-tags should be preserved with type=0"
+
+        # Verify newly added tag has type=1
+        extra = next((t for t in raw_tags if t["tag"] == "extra-tag"), None)
+        assert extra is not None, "Newly added tag should exist"
+        assert extra["type"] == 1, "Newly added tag should have type=1"
 
     @pytest.mark.asyncio
     async def test_add_empty_list_is_noop(

--- a/yazot/mcp_server.py
+++ b/yazot/mcp_server.py
@@ -821,7 +821,7 @@ async def remove_item(
     }
 
 
-@mcp.tool(annotations=ToolAnnotations(readOnlyHint=False))
+@mcp.tool(annotations=ToolAnnotations(readOnlyHint=False, idempotentHint=True))
 async def update_item_tags(
     item_key: str,
     tags: list[str],

--- a/yazot/mcp_server.py
+++ b/yazot/mcp_server.py
@@ -5,7 +5,7 @@ import os
 import tempfile
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
-from typing import Any
+from typing import Any, Literal
 
 import httpx
 from fastmcp import Context, FastMCP
@@ -21,6 +21,7 @@ from .models import (
     CollectionCreate,
     ExternalFulltextResponse,
     FulltextResponse,
+    ItemUpdate,
     Note,
     SearchCollectionResponse,
     VerificationResult,
@@ -112,6 +113,12 @@ If `has_more=True`, call `get_next_chunk` (search results) or `get_next_fulltext
 1. Find item using search or get_collection_items
 2. `remove_item(item_key="ABC123", collection_key="COL456")` — smart removal
 3. Or `remove_item(item_key="ABC123", from_library=True)` — force delete from library
+
+**Manage item tags:**
+1. Find item using search or get_collection_items
+2. `update_item_tags(item_key="ABC123", tags=["important", "to-read"])` — add tags (default)
+3. `update_item_tags(item_key="ABC123", tags=["to-read"], mode="remove")` — remove specific tags
+4. `update_item_tags(item_key="ABC123", tags=["reviewed"], mode="replace")` — replace all tags
 
 **Create and verify notes:**
 1. Find item using search or get_collection_items tool
@@ -811,6 +818,88 @@ async def remove_item(
         "action": "removed_from_collection",
         "item_key": item_key,
         "collection_key": collection_key_str,
+    }
+
+
+@mcp.tool(annotations=ToolAnnotations(readOnlyHint=False))
+async def update_item_tags(
+    item_key: str,
+    tags: list[str],
+    ctx: Context,
+    mode: Literal["add", "remove", "replace"] = "add",
+) -> dict[str, Any]:
+    """
+    Add, remove, or replace tags on a Zotero item.
+
+    Manages tags on an existing item with three modes:
+    - 'add' (default): append tags to existing ones, duplicates are ignored
+    - 'remove': remove specified tags, missing tags are silently ignored
+    - 'replace': replace all tags with the provided list, empty list clears all tags
+
+    New tags are created with type=1 (manual/user-created).
+    Existing tags preserve their original type.
+
+    Args:
+        item_key: The Zotero item key to update tags on
+        tags: List of tag names to add, remove, or set
+        mode: Operation mode — 'add', 'remove', or 'replace' (default: 'add')
+
+    Returns:
+        Dictionary with item_key, mode, tags_before, tags_after, and changed flag
+
+    Examples:
+        # Add tags to an item
+        update_item_tags(item_key="ABC123", tags=["important", "to-read"])
+
+        # Remove specific tags
+        update_item_tags(item_key="ABC123", tags=["to-read"], mode="remove")
+
+        # Replace all tags
+        update_item_tags(item_key="ABC123", tags=["reviewed"], mode="replace")
+
+        # Clear all tags
+        update_item_tags(item_key="ABC123", tags=[], mode="replace")
+    """
+    router: ZoteroClientRouter = _deps(ctx)["router"]
+
+    if mode == "replace":
+        new_tags = [ZoteroTag(tag=t, type=1) for t in tags]
+        tags_before: list[str] = []
+    else:
+        item = await router.get_item(item_key)
+        existing_tags = item.data.tags
+        tags_before = [t.tag for t in existing_tags]
+
+        if mode == "add":
+            existing_names = {t.tag for t in existing_tags}
+            new_tags = list(existing_tags)
+            for tag_name in tags:
+                if tag_name not in existing_names:
+                    new_tags.append(ZoteroTag(tag=tag_name, type=1))
+                    existing_names.add(tag_name)
+        else:  # mode == "remove"
+            remove_set = set(tags)
+            new_tags = [t for t in existing_tags if t.tag not in remove_set]
+
+    tags_after = [t.tag for t in new_tags]
+
+    if mode != "replace" and tags_before == tags_after:
+        return {
+            "item_key": item_key,
+            "mode": mode,
+            "tags_before": tags_before,
+            "tags_after": tags_after,
+            "changed": False,
+        }
+
+    await router.update_item(item_key, ItemUpdate(tags=new_tags))
+
+    return {
+        "item_key": item_key,
+        "mode": mode,
+        "tags_before": tags_before,
+        "tags_after": tags_after,
+        "changed": True,
     }
 
 

--- a/yazot/mcp_server.py
+++ b/yazot/mcp_server.py
@@ -869,15 +869,21 @@ async def update_item_tags(
     if mode == "replace":
         new_tags = [ZoteroTag(tag=t, type=1) for t in tags]
     elif mode == "add":
-        existing_names = {t.tag for t in existing_tags}
-        new_tags = list(existing_tags)
+        existing_names: set[str] = set()
+        new_tags = []
+        for existing in existing_tags:
+            if existing.tag not in existing_names:
+                existing_names.add(existing.tag)
+                new_tags.append(existing)
         for tag_name in tags:
             if tag_name not in existing_names:
                 new_tags.append(ZoteroTag(tag=tag_name, type=1))
                 existing_names.add(tag_name)
-    else:  # mode == "remove"
+    elif mode == "remove":
         remove_set = set(tags)
         new_tags = [t for t in existing_tags if t.tag not in remove_set]
+    else:
+        raise ZoteroError(f"Invalid mode: {mode!r}. Use 'add', 'remove', or 'replace'.")
 
     tags_after = [t.tag for t in new_tags]
 

--- a/yazot/mcp_server.py
+++ b/yazot/mcp_server.py
@@ -862,28 +862,26 @@ async def update_item_tags(
     """
     router: ZoteroClientRouter = _deps(ctx)["router"]
 
+    item = await router.get_item(item_key)
+    existing_tags = item.data.tags
+    tags_before = [t.tag for t in existing_tags]
+
     if mode == "replace":
         new_tags = [ZoteroTag(tag=t, type=1) for t in tags]
-        tags_before: list[str] = []
-    else:
-        item = await router.get_item(item_key)
-        existing_tags = item.data.tags
-        tags_before = [t.tag for t in existing_tags]
-
-        if mode == "add":
-            existing_names = {t.tag for t in existing_tags}
-            new_tags = list(existing_tags)
-            for tag_name in tags:
-                if tag_name not in existing_names:
-                    new_tags.append(ZoteroTag(tag=tag_name, type=1))
-                    existing_names.add(tag_name)
-        else:  # mode == "remove"
-            remove_set = set(tags)
-            new_tags = [t for t in existing_tags if t.tag not in remove_set]
+    elif mode == "add":
+        existing_names = {t.tag for t in existing_tags}
+        new_tags = list(existing_tags)
+        for tag_name in tags:
+            if tag_name not in existing_names:
+                new_tags.append(ZoteroTag(tag=tag_name, type=1))
+                existing_names.add(tag_name)
+    else:  # mode == "remove"
+        remove_set = set(tags)
+        new_tags = [t for t in existing_tags if t.tag not in remove_set]
 
     tags_after = [t.tag for t in new_tags]
 
-    if mode != "replace" and tags_before == tags_after:
+    if tags_before == tags_after:
         return {
             "item_key": item_key,
             "mode": mode,


### PR DESCRIPTION
## Summary
- Add `update_item_tags` tool with three modes: `add` (append, deduplicate), `remove` (by name), `replace` (full swap)
- No new production dependencies — reuses existing `ItemUpdate`, `ZoteroTag`, and `router.update_item()` infrastructure
- Preserves existing tag types (auto/manual) on untouched tags; new tags always type=1

## Summary by Sourcery

Add a new MCP tool for managing Zotero item tags and cover its behavior with end-to-end tests.

New Features:
- Introduce an update_item_tags MCP tool that can add, remove, or replace tags on a Zotero item while preserving existing tag types.

Tests:
- Add comprehensive end-to-end tests verifying tag addition, removal, replacement, no-op behavior, and error handling for the update_item_tags tool.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tag management for items with three modes: add (append new tags), remove (delete specified tags), and replace (set tags to the exact provided list).
  * Returns before/after tag state and a changed flag to indicate whether an update occurred.

* **Tests**
  * Added end-to-end tests covering add/remove/replace behaviors, idempotency, edge cases, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->