### PR TITLE
fix: add fastmcp-serialization rule, stabilize pydantic-settings tests

### DIFF
--- a/.claude/rules/fastmcp-serialization.md
+++ b/.claude/rules/fastmcp-serialization.md
@@ -1,0 +1,11 @@
+---
+globs: ["yazot/models.py", "yazot/mcp_server.py"]
+---
+
+# FastMCP response serialization
+
+- FastMCP generates `output_schema` via `type_adapter.json_schema(mode="serialization")`
+- `@model_serializer(mode="wrap")` on tool return types break this — schema degrades to `{"type": "object"}`, client gets raw dict instead of typed dataclass
+- `@model_serializer` on **nested** models (e.g. `ZoteroItem`) is fine — only top-level return types are affected
+- For slimming responses: use `to_slim_dict()` pattern (returns `model_dump(exclude_none=True)` as dict)
+- Return type annotation must stay as the Pydantic model (for schema generation), add `# type: ignore[return-value]`

--- a/tests/unit/test_external_fulltext.py
+++ b/tests/unit/test_external_fulltext.py
@@ -255,10 +255,10 @@ class TestFetchExternalFulltextNotConfigured:
 
     @pytest.fixture(autouse=True)
     def _clear_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Ensure no external fulltext config is set."""
-        monkeypatch.delenv("UNPAYWALL_EMAIL", raising=False)
-        monkeypatch.delenv("CORE_API_KEY", raising=False)
-        monkeypatch.delenv("FULLTEXT_LIBGEN_ENABLED", raising=False)
+        """Override .env values — delenv is not enough since pydantic-settings reads .env file."""
+        monkeypatch.setenv("UNPAYWALL_EMAIL", "")
+        monkeypatch.setenv("CORE_API_KEY", "")
+        monkeypatch.setenv("FULLTEXT_LIBGEN_ENABLED", "false")
 
     @pytest.mark.asyncio
     async def test_not_configured_raises_error(self) -> None:

--- a/tests/unit/test_fulltext_resolver.py
+++ b/tests/unit/test_fulltext_resolver.py
@@ -241,11 +241,18 @@ class TestFulltextResolver:
         return Settings(
             zotero_local=True,
             unpaywall_email="test@example.com",
+            core_api_key=None,
+            fulltext_libgen_enabled=False,
         )
 
     @pytest.fixture
     def settings_none(self) -> Settings:
-        return Settings(zotero_local=True)
+        return Settings(
+            zotero_local=True,
+            unpaywall_email=None,
+            core_api_key=None,
+            fulltext_libgen_enabled=False,
+        )
 
     def test_is_configured_all(self, settings_all: Settings) -> None:
         resolver = FulltextResolver(settings_all)


### PR DESCRIPTION
Recovers the still-relevant pieces of closed PR #32 against current main.

- Adds `.claude/rules/fastmcp-serialization.md` documenting how `@model_serializer` on top-level tool return types degrades the FastMCP-generated `output_schema` to `{"type": "object"}`.
- `test_external_fulltext` and `test_fulltext_resolver`: switch fixtures from `monkeypatch.delenv` to `setenv("", "")` / explicit `None` so `.env` no longer leaks into unit tests (consistent with `.claude/rules/testing-pydantic-settings.md`).

Pre-commit config changes from #32 are intentionally omitted — they were superseded by the migration to prek (#27).

## Summary by Sourcery

Document FastMCP serialization constraints and align external fulltext tests with pydantic-settings behavior.

Documentation:
- Add a FastMCP serialization rule describing how top-level model serializers affect generated output schemas and recommended patterns for slimming responses.

Tests:
- Adjust fulltext resolver and external fulltext tests to use explicit None/false configuration and environment overrides so .env contents do not leak into test behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Documentation**
* Added guidance documentation for internal serialization handling.

**Tests**
* Updated test fixtures to properly isolate external service configurations during testing.

**Note:** This release contains primarily internal improvements and documentation updates with no end-user facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->