### PR TITLE
feat: use markdown↔HTML conversion for Zotero notes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,8 @@ dependencies = [
     "httpx>=0.27.0",
     "pypdf>=6.10.0",
     "beautifulsoup4>=4.14.2",
+    "markdown>=3.7",
+    "markdownify>=0.14.1",
 ]
 
 [build-system]
@@ -81,4 +83,5 @@ dev = [
     "ipython>=8.0.0",
     "pytest-timeout>=2.4.0",
     "pytest-xdist>=3.5.0",
+    "types-markdown>=3.10.2.20260408",
 ]

--- a/tests/unit/test_formatters.py
+++ b/tests/unit/test_formatters.py
@@ -4,167 +4,124 @@ from yazot.formatters import extract_note_text, format_note_html
 
 
 class TestFormatNoteHtml:
-    """Tests for format_note_html() function."""
+    """Tests for format_note_html() — markdown to HTML conversion."""
 
-    def test_format_note_html_simple_text(self) -> None:
-        """Test HTML formatting with simple text."""
+    def test_simple_text(self) -> None:
         result = format_note_html("Hello world")
+        assert "<p>Hello world</p>" in result
 
-        assert result == "<p>Hello world</p>"
+    def test_paragraphs(self) -> None:
+        result = format_note_html("Paragraph 1\n\nParagraph 2")
+        assert "<p>Paragraph 1</p>" in result
+        assert "<p>Paragraph 2</p>" in result
 
-    def test_format_note_html_with_newlines(self) -> None:
-        """Test HTML formatting with single newlines."""
-        result = format_note_html("Line 1\nLine 2\nLine 3")
+    def test_heading(self) -> None:
+        result = format_note_html("## Key findings")
+        assert "<h2>Key findings</h2>" in result
 
-        assert result == "<p>Line 1<br>Line 2<br>Line 3</p>"
+    def test_blockquote(self) -> None:
+        result = format_note_html("> This is a quote")
+        assert "<blockquote>" in result
+        assert "This is a quote" in result
 
-    def test_format_note_html_with_paragraphs(self) -> None:
-        """Test HTML formatting with paragraph breaks (double newlines)."""
-        result = format_note_html("Paragraph 1\n\nParagraph 2\n\nParagraph 3")
+    def test_bold_and_italic(self) -> None:
+        result = format_note_html("**bold** and *italic*")
+        assert "<strong>bold</strong>" in result
+        assert "<em>italic</em>" in result
 
-        assert result == "<p>Paragraph 1</p><p>Paragraph 2</p><p>Paragraph 3</p>"
+    def test_unordered_list(self) -> None:
+        result = format_note_html("- Item 1\n- Item 2")
+        assert "<li>Item 1</li>" in result
+        assert "<li>Item 2</li>" in result
 
-    def test_format_note_html_escapes_html_chars(self) -> None:
-        """Test that HTML special characters are escaped."""
-        result = format_note_html("<script>alert('XSS')</script>")
-
-        assert "&lt;script&gt;" in result
-        assert "&lt;/script&gt;" in result
-        assert "<script>" not in result
-
-    def test_format_note_html_escapes_ampersand(self) -> None:
-        """Test that ampersands are escaped."""
+    def test_escapes_ampersand(self) -> None:
         result = format_note_html("Tom & Jerry")
-
         assert "&amp;" in result
-        assert result == "<p>Tom &amp; Jerry</p>"
 
-    def test_format_note_html_escapes_quotes(self) -> None:
-        """Test that quotes are escaped."""
-        result = format_note_html('He said "hello"')
-
-        assert "&quot;" in result or '"' in result  # Either escaped or preserved
-
-    def test_format_note_html_mixed_formatting(self) -> None:
-        """Test HTML formatting with mixed newlines and special chars."""
-        text = "Line 1 <tag>\n\nLine 2 & more\nLine 3"
-        result = format_note_html(text)
-
-        assert "&lt;tag&gt;" in result
-        assert "&amp;" in result
-        assert "<br>" in result
-        assert "</p><p>" in result
-
-    def test_format_note_html_empty_string(self) -> None:
-        """Test HTML formatting with empty string."""
+    def test_empty_string(self) -> None:
         result = format_note_html("")
-
-        assert result == "<p></p>"
-
-    def test_format_note_html_whitespace_only(self) -> None:
-        """Test HTML formatting with whitespace."""
-        result = format_note_html("   \n\n   ")
-
-        assert "<p>" in result
-        assert "</p>" in result
+        assert result == ""
 
 
 class TestExtractNoteText:
-    """Tests for extract_note_text() function."""
+    """Tests for extract_note_text() — HTML to markdown conversion."""
 
-    def test_extract_note_text_simple_paragraph(self) -> None:
-        """Test extracting text from simple paragraph."""
-        html = "<p>Hello world</p>"
-        result = extract_note_text(html)
+    def test_simple_paragraph(self) -> None:
+        result = extract_note_text("<p>Hello world</p>")
+        assert "Hello world" in result
 
-        assert result == "Hello world"
-
-    def test_extract_note_text_multiple_paragraphs(self) -> None:
-        """Test extracting text from multiple paragraphs."""
-        html = "<p>Paragraph 1</p><p>Paragraph 2</p>"
-        result = extract_note_text(html)
-
+    def test_multiple_paragraphs(self) -> None:
+        result = extract_note_text("<p>Paragraph 1</p><p>Paragraph 2</p>")
         assert "Paragraph 1" in result
         assert "Paragraph 2" in result
 
-    def test_extract_note_text_with_br_tags(self) -> None:
-        """Test extracting text with br tags."""
-        html = "<p>Line 1<br>Line 2<br>Line 3</p>"
-        result = extract_note_text(html)
+    def test_heading(self) -> None:
+        result = extract_note_text("<h2>Key findings</h2>")
+        assert "Key findings" in result
+        assert "##" in result
 
-        assert "Line 1" in result
-        assert "Line 2" in result
-        assert "Line 3" in result
-        assert "<br>" not in result
+    def test_blockquote_to_markdown(self) -> None:
+        result = extract_note_text("<blockquote><p>A quoted text</p></blockquote>")
+        assert "> " in result
+        assert "A quoted text" in result
 
-    def test_extract_note_text_strips_all_tags(self) -> None:
-        """Test that all HTML tags are stripped."""
-        html = "<div><p>Text with <strong>bold</strong> and <em>italic</em></p></div>"
-        result = extract_note_text(html)
+    def test_bold_and_italic(self) -> None:
+        result = extract_note_text("<p>Text with <strong>bold</strong> and <em>italic</em></p>")
+        assert "**bold**" in result
+        assert "*italic*" in result
 
-        assert result == "Text with bold and italic"
-        assert "<" not in result
-        assert ">" not in result
-
-    def test_extract_note_text_unescapes_entities(self) -> None:
-        """Test that HTML entities are unescaped."""
-        html = "<p>&lt;script&gt;alert(&quot;test&quot;)&lt;/script&gt;</p>"
-        result = extract_note_text(html)
-
-        assert result == '<script>alert("test")</script>'
-
-    def test_extract_note_text_ampersand(self) -> None:
-        """Test unescaping ampersands."""
-        html = "<p>Tom &amp; Jerry</p>"
-        result = extract_note_text(html)
-
-        assert result == "Tom & Jerry"
-
-    def test_extract_note_text_complex_html(self) -> None:
-        """Test extracting text from complex HTML structure."""
-        html = """
-        <div class="note">
-            <h1>Title</h1>
-            <p>First paragraph with <a href="#">link</a></p>
-            <ul>
-                <li>Item 1</li>
-                <li>Item 2</li>
-            </ul>
-        </div>
-        """
-        result = extract_note_text(html)
-
-        assert "Title" in result
-        assert "First paragraph with link" in result
+    def test_list(self) -> None:
+        result = extract_note_text("<ul><li>Item 1</li><li>Item 2</li></ul>")
         assert "Item 1" in result
         assert "Item 2" in result
-        assert "<" not in result
 
-    def test_extract_note_text_empty_html(self) -> None:
-        """Test extracting text from empty HTML."""
-        html = "<p></p>"
-        result = extract_note_text(html)
+    def test_unescapes_entities(self) -> None:
+        result = extract_note_text("<p>Tom &amp; Jerry</p>")
+        assert "Tom & Jerry" in result
 
+    def test_empty_html(self) -> None:
+        result = extract_note_text("<p></p>")
         assert result == ""
 
-    def test_extract_note_text_whitespace_normalization(self) -> None:
-        """Test that whitespace is handled properly."""
-        html = "<p>  Text with   spaces  </p>"
+    def test_complex_html(self) -> None:
+        html = """
+        <h1>Title</h1>
+        <p>First paragraph with <a href="#">link</a></p>
+        <ul>
+            <li>Item 1</li>
+            <li>Item 2</li>
+        </ul>
+        """
         result = extract_note_text(html)
+        assert "Title" in result
+        assert "Item 1" in result
+        assert "Item 2" in result
 
-        assert result == "Text with   spaces"  # Strip outer whitespace
+    def test_nested_tags(self) -> None:
+        result = extract_note_text("<div><div><p>Deep content</p></div></div>")
+        assert "Deep content" in result
 
-    def test_extract_note_text_nested_tags(self) -> None:
-        """Test extracting text from deeply nested tags."""
-        html = "<div><div><div><p>Deep content</p></div></div></div>"
+
+class TestRoundtrip:
+    """Tests that markdown → HTML → markdown preserves key elements."""
+
+    def test_blockquote_survives_roundtrip(self) -> None:
+        md_text = "Some text\n\n> This is a quoted passage\n\nMore text"
+        html = format_note_html(md_text)
         result = extract_note_text(html)
+        assert "> " in result
+        assert "This is a quoted passage" in result
 
-        assert result == "Deep content"
-
-    def test_extract_note_text_special_entities(self) -> None:
-        """Test unescaping special HTML entities."""
-        html = "<p>&copy; 2024 &mdash; Test &nbsp; Company</p>"
+    def test_heading_survives_roundtrip(self) -> None:
+        md_text = "# Title\n\n## Section"
+        html = format_note_html(md_text)
         result = extract_note_text(html)
+        assert "# Title" in result
+        assert "## Section" in result
 
-        assert "©" in result
-        assert "—" in result or "&mdash;" in result
+    def test_list_survives_roundtrip(self) -> None:
+        md_text = "- Point one\n- Point two"
+        html = format_note_html(md_text)
+        result = extract_note_text(html)
+        assert "Point one" in result
+        assert "Point two" in result

--- a/uv.lock
+++ b/uv.lock
@@ -701,6 +701,15 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown"
+version = "3.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/f4/69fa6ed85ae003c2378ffa8f6d2e3234662abd02c10d216c0ba96081a238/markdown-3.10.2.tar.gz", hash = "sha256:994d51325d25ad8aa7ce4ebaec003febcce822c3f8c911e3b17c52f7f589f950", size = 368805, upload-time = "2026-02-09T14:57:26.942Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/1f/77fa3081e4f66ca3576c896ae5d31c3002ac6607f9747d2e3aa49227e464/markdown-3.10.2-py3-none-any.whl", hash = "sha256:e91464b71ae3ee7afd3017d9f358ef0baf158fd9a298db92f1d4761133824c36", size = 108180, upload-time = "2026-02-09T14:57:25.787Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -710,6 +719,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
+name = "markdownify"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3f/bc/c8c8eea5335341306b0fa7e1cb33c5e1c8d24ef70ddd684da65f41c49c92/markdownify-1.2.2.tar.gz", hash = "sha256:b274f1b5943180b031b699b199cbaeb1e2ac938b75851849a31fd0c3d6603d09", size = 18816, upload-time = "2025-11-16T19:21:18.565Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/ce/f1e3e9d959db134cedf06825fae8d5b294bd368aacdd0831a3975b7c4d55/markdownify-1.2.2-py3-none-any.whl", hash = "sha256:3f02d3cc52714084d6e589f70397b6fc9f2f3a8531481bf35e8cc39f975e186a", size = 15724, upload-time = "2025-11-16T19:21:17.622Z" },
 ]
 
 [[package]]
@@ -1428,6 +1450,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9e/bd/3704a8c3e0942d711c1299ebf7b9091930adae6675d7c8f476a7ce48653c/sgmllib3k-1.0.0.tar.gz", hash = "sha256:7868fb1c8bfa764c1ac563d3cf369c381d1325d36124933a726f29fcdaa812e9", size = 5750, upload-time = "2010-08-24T14:33:52.445Z" }
 
 [[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
 name = "sniffio"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1491,6 +1522,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/eb/79/72064e6a701c2183016abbbfedaba506d81e30e232a68c9f0d6f6fcd1574/traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7", size = 161621, upload-time = "2024-04-19T11:11:49.746Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f", size = 85359, upload-time = "2024-04-19T11:11:46.763Z" },
+]
+
+[[package]]
+name = "types-markdown"
+version = "3.10.2.20260408"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dd/0e/a690840934c459aa50e0470e7550d7f151632eafa4a8e3c21d18009ad15c/types_markdown-3.10.2.20260408.tar.gz", hash = "sha256:d5cba15ed65a1420e80e31c17e3d4a2ad7208a3f3a4da97fd2c5f093caf523cd", size = 19784, upload-time = "2026-04-08T04:33:07.644Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/7e/265a8df257c8dced6ea89295f793a19f0a49ccbfeae1ed562368b2caf7a3/types_markdown-3.10.2.20260408-py3-none-any.whl", hash = "sha256:b0bbe8b7a8174db732067b86e391262898f5f536589ea81efec6d35ceb829331", size = 25857, upload-time = "2026-04-08T04:33:06.769Z" },
 ]
 
 [[package]]
@@ -1744,6 +1784,8 @@ dependencies = [
     { name = "beautifulsoup4" },
     { name = "fastmcp" },
     { name = "httpx" },
+    { name = "markdown" },
+    { name = "markdownify" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pypdf" },
@@ -1762,6 +1804,7 @@ dev = [
     { name = "pytest-timeout" },
     { name = "pytest-xdist" },
     { name = "ruff" },
+    { name = "types-markdown" },
 ]
 
 [package.metadata]
@@ -1769,6 +1812,8 @@ requires-dist = [
     { name = "beautifulsoup4", specifier = ">=4.14.2" },
     { name = "fastmcp", specifier = ">=3.1.0,<4.0.0" },
     { name = "httpx", specifier = ">=0.27.0" },
+    { name = "markdown", specifier = ">=3.7" },
+    { name = "markdownify", specifier = ">=0.14.1" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pydantic-settings", specifier = ">=2.0.0" },
     { name = "pypdf", specifier = ">=6.10.0" },
@@ -1787,6 +1832,7 @@ dev = [
     { name = "pytest-timeout", specifier = ">=2.4.0" },
     { name = "pytest-xdist", specifier = ">=3.5.0" },
     { name = "ruff", specifier = ">=0.6.0" },
+    { name = "types-markdown", specifier = ">=3.10.2.20260408" },
 ]
 
 [[package]]

--- a/yazot/formatters.py
+++ b/yazot/formatters.py
@@ -4,24 +4,22 @@ import html
 from collections.abc import Sequence
 from datetime import datetime
 
+import markdown as md
+import markdownify
 from bs4 import BeautifulSoup, Tag
 
 type NoteData = dict[str, str | int | float | Sequence[str | int | float | NoteData] | NoteData]
 
 
 def format_note_html(text: str) -> str:
-    """Format plain text as HTML note."""
-    # Escape HTML and convert newlines
-    text = html.escape(text)
-    text = text.replace("\n\n", "</p><p>")
-    text = text.replace("\n", "<br>")
-    return f"<p>{text}</p>"
+    """Convert markdown text to HTML for Zotero notes."""
+    return md.markdown(text, extensions=["extra"])
 
 
 def extract_note_text(html_content: str) -> str:
-    """Extract plain text from HTML note."""
-    soup = BeautifulSoup(html_content, "html.parser")
-    return soup.get_text().strip()
+    """Convert HTML note back to readable markdown."""
+    result: str = markdownify.markdownify(html_content, heading_style="ATX")
+    return result.strip()
 
 
 def parse_datetime(date_str: str) -> datetime:


### PR DESCRIPTION
- Replace naive `html.escape` + `<p>/<br>` in `format_note_html` with `markdown.markdown()` — proper `<blockquote>`, `<h2>`, `<ul>` rendering in Zotero
- Replace `BeautifulSoup.get_text()` in `extract_note_text` with `markdownify` — readable markdown output with `>` blockquotes preserved
- Fixes `verify_note` mechanism that couldn't find any quotes (blockquotes were lost in HTML→text roundtrip)

## Summary by Sourcery

Switch note formatting to use proper markdown↔HTML conversion for Zotero notes and ensure key structures survive roundtrips.

New Features:
- Support markdown-to-HTML rendering for Zotero notes, including headings, blockquotes, lists, and inline formatting.
- Support HTML-to-markdown conversion for Zotero notes to produce readable markdown output.

Bug Fixes:
- Preserve blockquotes and other structures in the HTML↔text roundtrip so quote verification can reliably detect quoted passages.

Enhancements:
- Simplify note formatting utilities to rely on dedicated markdown and HTML-to-markdown libraries instead of manual escaping and tag handling.

Build:
- Add markdown, markdownify, and typing stubs for markdown to the project dependencies.

Tests:
- Expand formatter tests to cover markdown→HTML rendering, HTML→markdown extraction, and roundtrip preservation of headings, blockquotes, and lists.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Notes now support full markdown formatting including headings, bold text, italic text, blockquotes, lists, and proper character escaping. Markdown is seamlessly converted to formatted HTML for display and back to markdown when needed.

* **Tests**
  * Expanded test coverage for note formatting functions to validate markdown-to-HTML conversion and roundtrip preservation.

* **Chores**
  * Updated dependencies with new markdown processing libraries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->