### PR TITLE
docs: improve Claude Code guidance based on posthoc analysis

### DIFF
--- a/.claude/rules/mypy-patterns.md
+++ b/.claude/rules/mypy-patterns.md
@@ -26,3 +26,10 @@ for result in results:
         continue
     # here result is narrowed to T
 ```
+
+# type: ignore и import stubs
+
+Проект использует `ignore_missing_imports = true` (pyproject.toml) — mypy НЕ ругается на импорт библиотек без стабов.
+Не добавляй `# type: ignore[import-untyped]` превентивно. Сначала запусти `uv run mypy yazot/`.
+
+`warn_unused_ignores = true` — лишние `type: ignore` комментарии вызывают ошибку.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,7 @@ uv run prek run --all-files
 - To resume work in an existing worktree — use `EnterWorktree` with the same name. Never `cd` into the worktree path directly
 - Worktrees contain only git-tracked files. `hooks/`, `settings.json`, `settings.local.json` live in `$CLAUDE_PROJECT_DIR/.claude/` and are shared — edit them from the main project path
 - `ExitWorktree(remove)` requires `discard_changes=true` if there are commits not in main (even if already pushed)
+- **PR creation**: global hook `pre-pr-review.sh` blocks `gh pr create` until `pr-diff-reviewer` agent completes. Run the review agent FIRST, wait for result, then create PR. Do NOT run both in parallel.
 - The Stop hook blocks session end in a worktree — ask the user to choose:
   1. **Push + PR**: commit all, `git push -u origin <branch>`, `gh pr create`, then `ExitWorktree(remove, discard_changes=true)`
   2. **Keep**: `ExitWorktree(keep)` — worktree stays for later

--- a/yazot/mcp_server.py
+++ b/yazot/mcp_server.py
@@ -92,6 +92,10 @@ If `has_more=True`, call `get_next_chunk` (search results) or `get_next_fulltext
 1. `search_articles(query="machine learning")` or `get_collection_items(collection_key="ABC123")`
 2. If `has_more=True`, call `get_next_chunk(chunk_id)` repeatedly
 3. For specific item, call `get_item_fulltext(item_key)`
+   **Note:** `search_articles` does NOT indicate fulltext availability.
+   If `get_item_fulltext` returns "No fulltext available", try `fetch_external_fulltext(item_key)` —
+   it downloads PDFs from open access sources (Unpaywall, CORE) and attaches them to the item.
+   Do NOT try `get_item_fulltext` on many items hoping to find one with text.
 4. If fulltext `has_more=True`, call `get_next_fulltext_chunk(chunk_id)` repeatedly
 
 **Fetch fulltext from external sources:**


### PR DESCRIPTION
- Add mypy rule: `ignore_missing_imports=true` means `type: ignore[import-untyped]` is unnecessary; `warn_unused_ignores` catches stale ignores
- MCP instructions: guide to use `fetch_external_fulltext` instead of repeated `get_item_fulltext` calls
- CLAUDE.md: document PR creation order (run `pr-diff-reviewer` before `gh pr create`)

## Summary by Sourcery

Document updated guidelines for mypy usage, MCP fulltext fetching, and PR creation flow.

Documentation:
- Clarify that import-related type ignores are generally unnecessary due to project-wide mypy settings and may be flagged as unused.
- Explain recommended use of `fetch_external_fulltext` instead of repeated `get_item_fulltext` calls when retrieving article fulltext via MCP.
- Describe the required order of running the `pr-diff-reviewer` agent before `gh pr create` due to the `pre-pr-review.sh` hook blocking parallel execution.