### PR TITLE
fix: handle Crossref authors without given name

### DIFF
--- a/tests/unit/test_crossref.py
+++ b/tests/unit/test_crossref.py
@@ -48,3 +48,68 @@ class TestCrossrefClient:
         assert item_dict["ISSN"] == "0028-0836"
         assert item_dict["date"] == "2023-08-15"
         assert item_dict["abstractNote"] == "This is a test abstract."
+
+    def test_crossref_to_zotero_organization_author(self) -> None:
+        """Author with family but no given name uses Zotero 'name' field."""
+        crossref_data = CrossrefWork(
+            type="journal-article",
+            DOI="10.1234/org",
+            title=["Consortium Study"],
+            author=[{"family": "WHO Research Consortium"}],
+            **{"container-title": ["Lancet"], "published-print": {"date-parts": [[2024]]}},
+        )
+
+        client = CrossrefClient()
+        item = client.crossref_to_zotero(crossref_data)
+        item_dict = item.model_dump(by_alias=True, exclude_none=True)
+
+        assert len(item_dict["creators"]) == 1
+        creator = item_dict["creators"][0]
+        assert creator["name"] == "WHO Research Consortium"
+        assert "firstName" not in creator
+        assert "lastName" not in creator
+
+    def test_crossref_to_zotero_mixed_authors(self) -> None:
+        """Mix of individual and organizational authors produces correct formats."""
+        crossref_data = CrossrefWork(
+            type="journal-article",
+            DOI="10.1234/mixed",
+            title=["Mixed Authors"],
+            author=[
+                {"given": "Alice", "family": "Chen"},
+                {"family": "ECOG-ACRIN Cancer Research Group"},
+                {"given": "Bob", "family": "Smith"},
+            ],
+            **{"container-title": ["JAMA"], "published-print": {"date-parts": [[2024]]}},
+        )
+
+        client = CrossrefClient()
+        item = client.crossref_to_zotero(crossref_data)
+        item_dict = item.model_dump(by_alias=True, exclude_none=True)
+
+        assert len(item_dict["creators"]) == 3
+        assert item_dict["creators"][0]["firstName"] == "Alice"
+        assert item_dict["creators"][0]["lastName"] == "Chen"
+        assert item_dict["creators"][1]["name"] == "ECOG-ACRIN Cancer Research Group"
+        assert "firstName" not in item_dict["creators"][1]
+        assert item_dict["creators"][2]["firstName"] == "Bob"
+        assert item_dict["creators"][2]["lastName"] == "Smith"
+
+    def test_crossref_to_zotero_given_only_author(self) -> None:
+        """Author with only given name (no family) uses 'name' field."""
+        crossref_data = CrossrefWork(
+            type="journal-article",
+            DOI="10.1234/given",
+            title=["Single Name"],
+            author=[{"given": "Sukarno"}],
+            **{"container-title": ["Journal"], "published-print": {"date-parts": [[2024]]}},
+        )
+
+        client = CrossrefClient()
+        item = client.crossref_to_zotero(crossref_data)
+        item_dict = item.model_dump(by_alias=True, exclude_none=True)
+
+        assert len(item_dict["creators"]) == 1
+        assert item_dict["creators"][0]["name"] == "Sukarno"
+        assert "firstName" not in item_dict["creators"][0]
+        assert "lastName" not in item_dict["creators"][0]

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,0 +1,53 @@
+"""Unit tests for Zotero write response models."""
+
+from yazot.models import ZoteroFailedItem, ZoteroWriteResponse
+
+
+class TestZoteroFailedItem:
+    def test_failed_item_without_key(self) -> None:
+        """HTTP 400 validation errors don't include a key field."""
+        item = ZoteroFailedItem(code=400, message='"firstName" is required if "lastName" is set')
+
+        assert item.key is None
+        assert item.code == 400
+        assert "firstName" in item.message
+
+    def test_failed_item_with_key(self) -> None:
+        """Standard failed items include a key field."""
+        item = ZoteroFailedItem(key="ABC123", code=409, message="Item already exists")
+
+        assert item.key == "ABC123"
+        assert item.code == 409
+
+
+class TestZoteroWriteResponse:
+    def test_write_response_with_keyless_failure(self) -> None:
+        """Response with failed items missing key parses correctly."""
+        raw = {
+            "successful": {},
+            "unchanged": {},
+            "failed": {
+                "0": {"code": 400, "message": '"firstName" is required'},
+            },
+        }
+
+        response = ZoteroWriteResponse.model_validate(raw)
+
+        assert response.has_failures()
+        assert response.failed["0"].code == 400
+        assert response.failed["0"].key is None
+
+    def test_write_response_mixed_success_and_failure(self) -> None:
+        """Response with both successful and failed items."""
+        raw = {
+            "successful": {"0": {"key": "XYZ789", "data": {}}},
+            "unchanged": {},
+            "failed": {
+                "1": {"code": 400, "message": "Validation error"},
+            },
+        }
+
+        response = ZoteroWriteResponse.model_validate(raw)
+
+        assert response.has_failures()
+        assert response.get_successful_keys() == ["XYZ789"]

--- a/yazot/crossref_client.py
+++ b/yazot/crossref_client.py
@@ -226,15 +226,17 @@ class CrossrefClient:
         for author in crossref_data.author:
             creator = {"creatorType": "author"}
 
-            # Crossref uses "given" and "family" for names
-            if author.family:
-                creator["lastName"] = author.family
-            if author.given:
+            if author.given and author.family:
                 creator["firstName"] = author.given
+                creator["lastName"] = author.family
+            elif author.family:
+                creator["name"] = author.family
+            elif author.given:
+                creator["name"] = author.given
+            else:
+                continue
 
-            # Only add if we have at least one name component
-            if "lastName" in creator or "firstName" in creator:
-                creators.append(creator)
+            creators.append(creator)
 
         # Build Zotero item
         zotero_item = {

--- a/yazot/exceptions.py
+++ b/yazot/exceptions.py
@@ -46,7 +46,8 @@ class ZoteroWriteError(ZoteroError):
     Args:
         operation: Type of operation (e.g., 'create_items', 'create_collections')
         failures: Dict mapping request indices to failure details
-                 Format: {"0": {"key": "", "code": 400, "message": "..."}, ...}
+                 Format: {"0": {"code": 400, "message": "...", "key": "..."}, ...}
+                 Note: "key" may be absent in HTTP 4xx validation errors
 
     Attributes:
         operation: Operation type that failed

--- a/yazot/models.py
+++ b/yazot/models.py
@@ -408,7 +408,7 @@ class CollectionCreate(BaseModel):
 class ZoteroFailedItem(BaseModel):
     """Failed item details from Zotero write operations."""
 
-    key: str
+    key: str | None = None
     code: int
     message: str
 


### PR DESCRIPTION
- Crossref authors with `family` but no `given` (organizations, consortiums) now use Zotero's `name` field instead of invalid `lastName`-only format that caused 400 errors
- `ZoteroFailedItem.key` is now optional so Zotero 400 responses parse correctly instead of causing `ValidationError`

## Summary by Sourcery

Handle Crossref authors lacking full personal name components and relax Zotero failure response modeling to support keyless 4xx errors.

Bug Fixes:
- Map Crossref authors with only a family or only a given name to Zotero's single `name` field instead of requiring both first and last names, preventing invalid creator payloads that trigger 400 responses.
- Allow Zotero write failure items to omit the `key` field so 4xx validation responses parse correctly without raising validation errors.

Tests:
- Add unit tests covering Crossref-to-Zotero conversion for organizational authors, mixed individual/organizational author lists, and given-name-only authors.
- Add unit tests verifying ZoteroFailedItem and ZoteroWriteResponse correctly handle failed items without keys as well as mixed success/failure responses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved author-to-creator mapping to handle various name formats (given-only, family-only, or organization names).
  * Enhanced error handling to gracefully accept Zotero API responses where the key field may be absent.

* **Documentation**
  * Updated error documentation to clarify Zotero API response structure.

* **Tests**
  * Added comprehensive validation tests for author formatting and API response parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->