### PR TITLE
docs: add worktree PR workflow rules

### DIFF
--- a/.claude/rules/worktree-pr-workflow.md
+++ b/.claude/rules/worktree-pr-workflow.md
@@ -1,0 +1,21 @@
+# Worktree PR workflow
+
+## PR creation sequence
+
+1. Finish ALL code changes (including nit-fixes, docstring updates)
+2. Commit and push
+3. Run `pr-diff-reviewer` agent
+4. Only then `gh pr create`
+
+Each new commit after review invalidates it — the hook checks SHA match.
+Do NOT fix reviewer nits after review; fix them before, then re-review.
+
+## gh pr merge from worktree
+
+`gh pr merge` without `--repo` fails in a worktree because local git can't checkout main.
+Always use: `gh pr merge N --squash --delete-branch --repo owner/repo`
+
+## Files after EnterWorktree
+
+Files read from the main project path are NOT counted as read for worktree paths.
+After `EnterWorktree`, re-read files before editing them.


### PR DESCRIPTION
- Captures lessons from posthoc session analysis: PR review must happen after all commits, `gh pr merge` needs `--repo` from worktree, files need re-read after `EnterWorktree`

## Summary by Sourcery

Document a standardized workflow for creating and merging PRs when using git worktrees and Claude agents.

Documentation:
- Add documentation describing the required PR creation sequence when using the pr-diff-reviewer agent.
- Document the need to pass --repo when running gh pr merge from a worktree context.
- Clarify that files must be re-read after EnterWorktree because main project paths and worktree paths are tracked separately.