### PR TITLE
feat: add update_note endpoint

### DIFF
--- a/tests/e2e/test_update_note.py
+++ b/tests/e2e/test_update_note.py
@@ -65,9 +65,7 @@ class TestUpdateNoteEndpoint:
         assert note.parent_key == created_note["item_key"]
 
     @pytest.mark.asyncio
-    async def test_update_note_preserves_tags(
-        self, created_note: dict, test_zotero_client: ZoteroClient
-    ) -> None:
+    async def test_update_note_preserves_tags(self, created_note: dict) -> None:
         # First add tags via update_item_tags
         async with Client(mcp) as client:
             await client.call_tool(
@@ -104,5 +102,5 @@ class TestUpdateNoteEndpoint:
             )
             note = result.data
 
-        assert "summary" in note.content
+        assert "Summary" in note.content
         assert "Updated analysis" in note.content

--- a/tests/e2e/test_update_note.py
+++ b/tests/e2e/test_update_note.py
@@ -1,0 +1,108 @@
+"""E2E tests for update_note_for_item endpoint."""
+
+import pytest
+from fastmcp import Client
+
+from yazot.mcp_server import mcp
+from yazot.zotero_client import ZoteroClient
+
+
+class TestUpdateNoteEndpoint:
+    @pytest.fixture
+    async def created_note(
+        self,
+        test_data_manager,
+        test_zotero_client: ZoteroClient,
+    ) -> dict:
+        """Create a test item with a note, return both keys."""
+        items = await test_data_manager.create_test_items(
+            count=1,
+            template_type="journalArticle",
+        )
+        item_key = items[0].key
+
+        async with Client(mcp) as client:
+            result = await client.call_tool(
+                "create_note_for_item",
+                arguments={
+                    "item_key": item_key,
+                    "title": "Original Title",
+                    "content": "Original content before update.",
+                },
+            )
+            note = result.data
+
+        return {"item_key": item_key, "note_key": note.key}
+
+    @pytest.mark.asyncio
+    async def test_update_note_replaces_content(self, created_note: dict) -> None:
+        async with Client(mcp) as client:
+            result = await client.call_tool(
+                "update_note_for_item",
+                arguments={
+                    "note_key": created_note["note_key"],
+                    "content": "# Updated Title\n\nNew content after update.",
+                },
+            )
+            note = result.data
+
+        assert note.key == created_note["note_key"]
+        assert "New content after update" in note.content
+        assert "Original content" not in note.content
+
+    @pytest.mark.asyncio
+    async def test_update_note_preserves_parent(self, created_note: dict) -> None:
+        async with Client(mcp) as client:
+            result = await client.call_tool(
+                "update_note_for_item",
+                arguments={
+                    "note_key": created_note["note_key"],
+                    "content": "Updated content.",
+                },
+            )
+            note = result.data
+
+        assert note.parent_key == created_note["item_key"]
+
+    @pytest.mark.asyncio
+    async def test_update_note_preserves_tags(
+        self, created_note: dict, test_zotero_client: ZoteroClient
+    ) -> None:
+        # First add tags via update_item_tags
+        async with Client(mcp) as client:
+            await client.call_tool(
+                "update_item_tags",
+                arguments={
+                    "item_key": created_note["note_key"],
+                    "tags": ["important", "review"],
+                    "mode": "add",
+                },
+            )
+
+            # Now update note content
+            result = await client.call_tool(
+                "update_note_for_item",
+                arguments={
+                    "note_key": created_note["note_key"],
+                    "content": "Content updated, tags should remain.",
+                },
+            )
+            note = result.data
+
+        assert "important" in note.tags
+        assert "review" in note.tags
+
+    @pytest.mark.asyncio
+    async def test_update_note_with_dict_content(self, created_note: dict) -> None:
+        async with Client(mcp) as client:
+            result = await client.call_tool(
+                "update_note_for_item",
+                arguments={
+                    "note_key": created_note["note_key"],
+                    "content": {"summary": "Updated analysis", "rating": 5},
+                },
+            )
+            note = result.data
+
+        assert "summary" in note.content
+        assert "Updated analysis" in note.content

--- a/tests/unit/test_note_manager.py
+++ b/tests/unit/test_note_manager.py
@@ -1,0 +1,108 @@
+"""Unit tests for NoteManager.update_note()."""
+
+from datetime import datetime
+from unittest.mock import AsyncMock
+
+import pytest
+
+from yazot.exceptions import ZoteroNotFoundError
+from yazot.note_manager import NoteManager
+
+
+def _make_raw_note(
+    key: str = "NOTE0001",
+    parent_key: str = "PARENT01",
+    note_html: str = "<p>old content</p>",
+    tags: list[dict] | None = None,
+) -> dict:
+    return {
+        "key": key,
+        "data": {
+            "parentItem": parent_key,
+            "note": note_html,
+            "dateAdded": "2025-01-01T00:00:00Z",
+            "dateModified": "2025-01-01T12:00:00Z",
+            "tags": tags or [],
+        },
+    }
+
+
+class TestUpdateNote:
+    @pytest.fixture
+    def mock_client(self) -> AsyncMock:
+        client = AsyncMock()
+        client.update_item = AsyncMock()
+        client.get_raw_item = AsyncMock(return_value=_make_raw_note())
+        return client
+
+    @pytest.fixture
+    def note_manager(self, mock_client: AsyncMock) -> NoteManager:
+        return NoteManager(mock_client)
+
+    @pytest.mark.asyncio
+    async def test_update_note_with_string_content(
+        self, note_manager: NoteManager, mock_client: AsyncMock
+    ) -> None:
+        result = await note_manager.update_note("NOTE0001", "new plain text")
+
+        mock_client.update_item.assert_called_once()
+        call_args = mock_client.update_item.call_args
+        assert call_args[0][0] == "NOTE0001"
+        update = call_args[0][1]
+        assert update.note is not None
+        assert result.key == "NOTE0001"
+
+    @pytest.mark.asyncio
+    async def test_update_note_with_dict_content(
+        self, note_manager: NoteManager, mock_client: AsyncMock
+    ) -> None:
+        content = {"summary": "Test summary", "findings": ["A", "B"]}
+        result = await note_manager.update_note("NOTE0001", content)
+
+        mock_client.update_item.assert_called_once()
+        assert result.key == "NOTE0001"
+
+    @pytest.mark.asyncio
+    async def test_update_note_with_json_string(
+        self, note_manager: NoteManager, mock_client: AsyncMock
+    ) -> None:
+        content = '{"summary": "Test summary"}'
+        result = await note_manager.update_note("NOTE0001", content)
+
+        mock_client.update_item.assert_called_once()
+        assert result.key == "NOTE0001"
+
+    @pytest.mark.asyncio
+    async def test_update_note_preserves_tags(
+        self, note_manager: NoteManager, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get_raw_item.return_value = _make_raw_note(
+            tags=[{"tag": "important", "type": 1}, {"tag": "verified", "type": 1}]
+        )
+
+        result = await note_manager.update_note("NOTE0001", "updated content")
+
+        # update_item should NOT include tags (content-only update)
+        update = mock_client.update_item.call_args[0][1]
+        assert update.tags is None
+        # Returned note should still have existing tags
+        assert result.tags == ["important", "verified"]
+
+    @pytest.mark.asyncio
+    async def test_update_note_returns_refreshed_metadata(
+        self, note_manager: NoteManager, mock_client: AsyncMock
+    ) -> None:
+        result = await note_manager.update_note("NOTE0001", "new content")
+
+        assert result.parent_key == "PARENT01"
+        assert isinstance(result.created, datetime)
+        assert isinstance(result.modified, datetime)
+
+    @pytest.mark.asyncio
+    async def test_update_note_not_found(
+        self, note_manager: NoteManager, mock_client: AsyncMock
+    ) -> None:
+        mock_client.update_item.side_effect = ZoteroNotFoundError("item", "BADKEY01")
+
+        with pytest.raises(ZoteroNotFoundError):
+            await note_manager.update_note("BADKEY01", "content")

--- a/yazot/mcp_server.py
+++ b/yazot/mcp_server.py
@@ -369,6 +369,30 @@ async def create_note_for_item(
     return note
 
 
+@mcp.tool(annotations=ToolAnnotations(readOnlyHint=False))
+async def update_note_for_item(
+    note_key: str,
+    content: str | dict[str, Any],
+    ctx: Context,
+) -> Note:
+    """
+    Update an existing note's content in-place by note key.
+
+    Use this instead of creating a new note when you need to fix or revise
+    content (e.g., correcting quotes after failed verification).
+    To manage tags, use update_item_tags separately.
+
+    Args:
+        note_key: The Zotero key of the note to update
+        content: New note content - plain text string or structured dict
+
+    Returns:
+        Updated Note object with key, content, timestamps, and tags
+    """
+    note_manager: NoteManager = _deps(ctx)["note_manager"]
+    return await note_manager.update_note(note_key=note_key, content=content)
+
+
 @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True, idempotentHint=True))
 async def get_item_notes(item_key: str, ctx: Context) -> list[Note]:
     """

--- a/yazot/note_manager.py
+++ b/yazot/note_manager.py
@@ -25,18 +25,19 @@ class NoteManager:
         """
         self.client = client
 
-    async def create_note(
-        self, item_key: str, content: str | dict[str, Any], tags: list[str] | None = None
-    ) -> Note:
-        """Create a new note for an item."""
-        # Convert dict to string if needed
+    @staticmethod
+    def _content_to_html(content: str | dict[str, Any]) -> tuple[str, str]:
+        """Convert content to HTML for Zotero storage.
+
+        Returns (content_str, note_html) where content_str is the plain text
+        representation and note_html is the HTML for Zotero.
+        """
         is_html = False
         match content:
             case dict():
                 content_str = format_dict_to_html(content)
                 is_html = True
             case str():
-                # Try to parse as JSON and convert to dict
                 try:
                     content_dict = json.loads(content)
                     content_str = format_dict_to_html(content_dict)
@@ -47,6 +48,13 @@ class NoteManager:
                 content_str = str(content)
 
         note_html = content_str if is_html else format_note_html(content_str)
+        return content_str, note_html
+
+    async def create_note(
+        self, item_key: str, content: str | dict[str, Any], tags: list[str] | None = None
+    ) -> Note:
+        """Create a new note for an item."""
+        content_str, note_html = self._content_to_html(content)
         note_item = ItemCreate(
             item_type="note",
             parent_item=item_key,
@@ -73,22 +81,7 @@ class NoteManager:
 
     async def update_note(self, note_key: str, content: str | dict[str, Any]) -> Note:
         """Update an existing note's content in-place."""
-        is_html = False
-        match content:
-            case dict():
-                content_str = format_dict_to_html(content)
-                is_html = True
-            case str():
-                try:
-                    content_dict = json.loads(content)
-                    content_str = format_dict_to_html(content_dict)
-                    is_html = True
-                except (json.JSONDecodeError, ValueError):
-                    content_str = content
-            case _:
-                content_str = str(content)
-
-        note_html = content_str if is_html else format_note_html(content_str)
+        _, note_html = self._content_to_html(content)
         await self.client.update_item(note_key, ItemUpdate(note=note_html))
         return await self.get_note(note_key)
 

--- a/yazot/note_manager.py
+++ b/yazot/note_manager.py
@@ -8,7 +8,7 @@ from .formatters import (
     format_note_html,
     parse_datetime,
 )
-from .models import ItemCreate, Note, ZoteroTag
+from .models import ItemCreate, ItemUpdate, Note, ZoteroTag
 
 if TYPE_CHECKING:
     from .protocols import ZoteroClientProtocol
@@ -70,6 +70,27 @@ class NoteManager:
             modified=parse_datetime(created_note.data.date_modified),
             tags=tags or [],
         )
+
+    async def update_note(self, note_key: str, content: str | dict[str, Any]) -> Note:
+        """Update an existing note's content in-place."""
+        is_html = False
+        match content:
+            case dict():
+                content_str = format_dict_to_html(content)
+                is_html = True
+            case str():
+                try:
+                    content_dict = json.loads(content)
+                    content_str = format_dict_to_html(content_dict)
+                    is_html = True
+                except (json.JSONDecodeError, ValueError):
+                    content_str = content
+            case _:
+                content_str = str(content)
+
+        note_html = content_str if is_html else format_note_html(content_str)
+        await self.client.update_item(note_key, ItemUpdate(note=note_html))
+        return await self.get_note(note_key)
 
     async def get_notes_for_item(self, item_key: str) -> list[Note]:
         """Get all notes for a specific item."""


### PR DESCRIPTION
## Summary

- Add `update_note` to NoteManager + `update_note_for_item` MCP tool for in-place note content updates by note_key
- Tags intentionally excluded — use existing `update_item_tags` separately (avoids accidental tag replacement)
- Solves orphan "unverified" notes from zotero-research-agent's create→verify→retry loop

## Summary by Sourcery

Add support for updating existing Zotero notes in place via a new MCP endpoint and corresponding NoteManager method, while ensuring tags and parent relationships are preserved.

New Features:
- Expose an update_note_for_item MCP tool to update an existing note's content by note key.
- Add a NoteManager.update_note method to perform content-only updates on Zotero notes, accepting plain text, JSON strings, or dict payloads.

Tests:
- Add end-to-end tests covering the update_note_for_item tool, including content replacement, parent preservation, tag preservation, and dict content handling.
- Add unit tests for NoteManager.update_note to verify formatting behavior, tag preservation, metadata refresh, and not-found error handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to update existing note content in place, supporting both plain text and structured data formats (such as dictionaries).

* **Tests**
  * Added comprehensive end-to-end and unit test coverage for note updates, validating content replacement, preservation of parent relationships, tag retention, and handling of various content formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->