### PR TITLE
docs: add fastmcp-serialization rule

### DIFF
--- a/.claude/rules/fastmcp-serialization.md
+++ b/.claude/rules/fastmcp-serialization.md
@@ -1,0 +1,11 @@
+---
+globs: ["yazot/models.py", "yazot/mcp_server.py"]
+---
+
+# FastMCP response serialization
+
+- FastMCP generates `output_schema` via `type_adapter.json_schema(mode="serialization")`
+- `@model_serializer(mode="wrap")` on tool return types break this — schema degrades to `{"type": "object"}`, client gets raw dict instead of typed dataclass
+- `@model_serializer` on **nested** models (e.g. `ZoteroItem`) is fine — only top-level return types are affected
+- For slimming responses: use `to_slim_dict()` pattern (returns `model_dump(exclude_none=True)` as dict)
+- Return type annotation must stay as the Pydantic model (for schema generation), add `# type: ignore[return-value]`


### PR DESCRIPTION
- Document how `@model_serializer(mode="wrap")` on top-level tool return types degrades FastMCP `output_schema` and the `to_slim_dict()` workaround
- Extracted from closed #43 — test fixes from that PR were already on main or obsoleted by #30

## Summary by Sourcery

Documentation:
- Add internal documentation outlining how FastMCP generates output schemas, how top-level `@model_serializer(mode="wrap")` affects serialization, and the recommended `to_slim_dict()` pattern and typing guidance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation on schema generation and serialization behavior, detailing best practices for tool return type handling, model serializer patterns, and guidance for optimizing responses while maintaining proper type safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->