### PR TITLE
docs: document worktree re-entry behavior

### DIFF
--- a/.claude/rules/worktree-pr-workflow.md
+++ b/.claude/rules/worktree-pr-workflow.md
@@ -15,6 +15,11 @@ Do NOT fix reviewer nits after review; fix them before, then re-review.
 `gh pr merge` without `--repo` fails in a worktree because local git can't checkout main.
 Always use: `gh pr merge N --squash --delete-branch --repo owner/repo`
 
+## Re-entry after ExitWorktree(remove)
+
+`EnterWorktree(name)` after `ExitWorktree(remove)` creates a fresh worktree on main — the PR branch commits are NOT there.
+To restore: `git pull origin <branch-name>` (upstream tracking is also lost, so use `push -u` afterwards).
+
 ## Files after EnterWorktree
 
 Files read from the main project path are NOT counted as read for worktree paths.

--- a/yazot/formatters.py
+++ b/yazot/formatters.py
@@ -36,7 +36,7 @@ def parse_datetime(date_str: str) -> datetime:
 
 
 def format_dict_to_html(data: NoteData, level: int = 1) -> str:
-    """Convert dictionary to HTML with keys as headers.
+    """Convert dictionary to HTML with keys as headers (capitalized).
 
     Args:
         data: Dictionary to convert


### PR DESCRIPTION
## Summary

- Document that `EnterWorktree` after `ExitWorktree(remove)` creates a fresh worktree on main without PR branch commits or upstream tracking
- Clarify `format_dict_to_html` docstring: dict keys are capitalized as headers

## Summary by Sourcery

Document worktree re-entry behavior after removing a worktree and clarify HTML formatting behavior in the formatter docstring.

Documentation:
- Add documentation explaining that re-entering a removed worktree creates a fresh worktree on main without PR branch commits or upstream tracking, and how to restore the branch state.
- Clarify the `format_dict_to_html` docstring to note that dictionary keys are capitalized when rendered as headers.