### PR TITLE
fix: retry once on 412 version conflict in add_to_collection

### DIFF
--- a/tests/unit/test_zotero_client.py
+++ b/tests/unit/test_zotero_client.py
@@ -1,0 +1,99 @@
+"""Tests for ZoteroClient.add_to_collection retry logic."""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pyzotero import zotero_errors
+
+from yazot.exceptions import ZoteroError
+from yazot.models import ZoteroItem
+
+
+def _make_item(key: str = "TESTKEY1", version: int = 100) -> ZoteroItem:
+    """Create a minimal ZoteroItem for testing."""
+    return ZoteroItem.model_validate(
+        {
+            "key": key,
+            "version": version,
+            "data": {
+                "key": key,
+                "version": version,
+                "itemType": "journalArticle",
+                "title": "Test Article",
+                "collections": [],
+            },
+            "meta": {},
+        }
+    )
+
+
+def _make_zotero_client() -> Any:
+    """Create a ZoteroClient with mocked internals for unit testing."""
+    with patch("yazot.zotero_client.ZoteroClient.__init__", return_value=None):
+        from yazot.zotero_client import ZoteroClient
+
+        zc = ZoteroClient.__new__(ZoteroClient)
+        zc._mode = "web"
+        zc._client = MagicMock()  # pyzotero client stub
+        zc._call = AsyncMock(return_value=None)
+        return zc
+
+
+class TestAddToCollectionRetry:
+    """Test 412 PreConditionFailed retry in add_to_collection."""
+
+    @pytest.mark.asyncio
+    async def test_success_no_retry(self) -> None:
+        """Normal add without version conflict — no retry needed."""
+        zc = _make_zotero_client()
+        item = _make_item()
+
+        await zc._add_item_to_collection("COLL1", item)
+
+        zc._call.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_retry_on_412(self) -> None:
+        """412 triggers re-fetch and single retry."""
+        zc = _make_zotero_client()
+        fresh_item = _make_item(version=200)
+
+        zc._call = AsyncMock(side_effect=[zotero_errors.PreConditionFailedError("412"), None])
+        zc.get_item = AsyncMock(return_value=fresh_item)
+
+        item = _make_item(version=100)
+        await zc._add_item_to_collection("COLL1", item)
+
+        assert zc._call.call_count == 2
+        zc.get_item.assert_called_once_with("TESTKEY1")
+
+    @pytest.mark.asyncio
+    async def test_412_after_retry_raises(self) -> None:
+        """Second 412 after retry raises ZoteroError."""
+        zc = _make_zotero_client()
+        fresh_item = _make_item(version=200)
+
+        zc._call = AsyncMock(
+            side_effect=[
+                zotero_errors.PreConditionFailedError("412"),
+                zotero_errors.PreConditionFailedError("412 again"),
+            ]
+        )
+        zc.get_item = AsyncMock(return_value=fresh_item)
+
+        item = _make_item(version=100)
+        with pytest.raises(ZoteroError, match="Version conflict.*after retry"):
+            await zc._add_item_to_collection("COLL1", item)
+
+    @pytest.mark.asyncio
+    async def test_non_412_error_not_retried(self) -> None:
+        """Non-412 PyZoteroError is not retried."""
+        zc = _make_zotero_client()
+        zc._call = AsyncMock(side_effect=zotero_errors.PyZoteroError("500 Server Error"))
+
+        item = _make_item()
+        with pytest.raises(ZoteroError, match="Failed to add item"):
+            await zc._add_item_to_collection("COLL1", item)
+
+        zc._call.assert_called_once()

--- a/yazot/zotero_client.py
+++ b/yazot/zotero_client.py
@@ -753,30 +753,45 @@ class ZoteroClient(ZoteroClientProtocol):
     async def add_to_collection(self, collection_key: str, items: list[ZoteroItem]) -> None:
         """Add items to a collection."""
         for item in items:
-            try:
-                await self._call(
-                    self._client.addto_collection,
-                    collection_key,
-                    item.model_dump(by_alias=True),
-                )
-            except zotero_errors.ResourceNotFoundError as e:
-                raise ZoteroNotFoundError("collection", collection_key) from e
-            except zotero_errors.UserNotAuthorisedError as e:
+            await self._add_item_to_collection(collection_key, item)
+
+    async def _add_item_to_collection(
+        self, collection_key: str, item: ZoteroItem, *, retried: bool = False
+    ) -> None:
+        """Add a single item to a collection, retrying once on version conflict."""
+        try:
+            await self._call(
+                self._client.addto_collection,
+                collection_key,
+                item.model_dump(by_alias=True),
+            )
+        except zotero_errors.PreConditionFailedError as e:
+            if retried:
                 raise ZoteroError(
-                    f"Not authorized to modify collection '{collection_key}'. "
-                    "Hint: check that ZOTERO_API_KEY has write permissions."
+                    f"Version conflict for item '{item.key}' in collection '{collection_key}' "
+                    "after retry. Hint: the item is being modified by another client."
                 ) from e
-            except zotero_errors.PyZoteroError as e:
-                raise ZoteroError(
-                    f"Failed to add item '{item.key}' to collection '{collection_key}': {e}. "
-                    "Hint: verify the collection key exists and credentials are correct."
-                ) from e
-            except Exception as e:
-                raise ZoteroError(
-                    f"Unexpected error adding item '{item.key}' to collection "
-                    f"'{collection_key}': {type(e).__name__}: {e}. "
-                    "Hint: check network connectivity and web API credentials."
-                ) from e
+            logger.debug("Version conflict for item '%s', re-fetching and retrying", item.key)
+            fresh_item = await self.get_item(item.key)
+            await self._add_item_to_collection(collection_key, fresh_item, retried=True)
+        except zotero_errors.ResourceNotFoundError as e:
+            raise ZoteroNotFoundError("collection", collection_key) from e
+        except zotero_errors.UserNotAuthorisedError as e:
+            raise ZoteroError(
+                f"Not authorized to modify collection '{collection_key}'. "
+                "Hint: check that ZOTERO_API_KEY has write permissions."
+            ) from e
+        except zotero_errors.PyZoteroError as e:
+            raise ZoteroError(
+                f"Failed to add item '{item.key}' to collection '{collection_key}': {e}. "
+                "Hint: verify the collection key exists and credentials are correct."
+            ) from e
+        except Exception as e:
+            raise ZoteroError(
+                f"Unexpected error adding item '{item.key}' to collection "
+                f"'{collection_key}': {type(e).__name__}: {e}. "
+                "Hint: check network connectivity and web API credentials."
+            ) from e
 
     @webonly
     async def attach_pdf(self, item_key: str, filepath: str) -> None:


### PR DESCRIPTION
## Summary

- Catch `PreConditionFailedError` (HTTP 412) in `add_to_collection`, re-fetch the item for a fresh version, and retry the PATCH once
- Previously 412 was swallowed by the generic `PyZoteroError` handler with no recovery, causing silent failures when items were modified between fetch and PATCH (e.g. by Zotero client sync)

## Summary by Sourcery

Handle Zotero collection updates more robustly by retrying once on version conflicts and adding targeted tests for the new behavior.

Bug Fixes:
- Retry a collection update once after a 412 PreConditionFailedError by refetching the item with a fresh version to avoid silent failures when items change between fetch and update.

Enhancements:
- Extract adding a single item to a collection into a dedicated helper to support retry logic on version conflicts.

Tests:
- Add unit tests covering successful collection updates, single retry on 412, failure after a second 412, and non-retriable errors for add-to-collection operations.