### PR TITLE
fix: sanitize U+FFFD replacement characters in note content

### DIFF
--- a/.claude/rules/worktree-pr-workflow.md
+++ b/.claude/rules/worktree-pr-workflow.md
@@ -15,6 +15,11 @@ Do NOT fix reviewer nits after review; fix them before, then re-review.
 `gh pr merge` without `--repo` fails in a worktree because local git can't checkout main.
 Always use: `gh pr merge N --squash --delete-branch --repo owner/repo`
 
+## Re-entry after ExitWorktree(remove)
+
+`EnterWorktree(name)` after `ExitWorktree(remove)` creates a fresh worktree on main — the PR branch commits are NOT there.
+To restore: `git pull origin <branch-name>` (upstream tracking is also lost, so use `push -u` afterwards).
+
 ## Files after EnterWorktree
 
 Files read from the main project path are NOT counted as read for worktree paths.

--- a/tests/unit/test_formatters.py
+++ b/tests/unit/test_formatters.py
@@ -4,6 +4,7 @@ import logging
 
 import pytest
 
+import yazot.formatters as formatters_module
 from yazot.formatters import extract_note_text, format_note_html
 
 
@@ -109,6 +110,10 @@ class TestExtractNoteText:
 class TestExtractNoteTextUnicode:
     """Tests for Unicode handling in extract_note_text()."""
 
+    @pytest.fixture(autouse=True)
+    def _reset_log_counter(self) -> None:
+        formatters_module._replacement_char_notes_logged = 0
+
     def test_cyrillic_text_preserved(self) -> None:
         html = "<p>Перитонеальные рецепторы</p>"
         result = extract_note_text(html)
@@ -140,11 +145,36 @@ class TestExtractNoteTextUnicode:
         assert "中文" in result
         assert "العربية" in result
 
+    def test_multiple_replacement_chars(self) -> None:
+        html = "<p>\ufffdstart mid\ufffddle end\ufffd</p>"
+        result = extract_note_text(html)
+        assert "\ufffd" not in result
+        assert "start middle end" in result
+
+    def test_replacement_char_at_boundaries(self) -> None:
+        html = "<p>\ufffdtext\ufffd</p>"
+        result = extract_note_text(html)
+        assert result == "text"
+
+    def test_only_replacement_chars(self) -> None:
+        html = "<p>\ufffd\ufffd\ufffd</p>"
+        result = extract_note_text(html)
+        assert result == ""
+
     def test_clean_text_no_warning(self, caplog: pytest.LogCaptureFixture) -> None:
         html = "<p>Clean text without issues</p>"
         with caplog.at_level(logging.WARNING, logger="yazot.formatters"):
             extract_note_text(html)
         assert "U+FFFD" not in caplog.text
+
+    def test_log_rate_limiting(self, caplog: pytest.LogCaptureFixture) -> None:
+        html = "<p>\ufffdx</p>"
+        with caplog.at_level(logging.WARNING, logger="yazot.formatters"):
+            for _ in range(12):
+                caplog.clear()
+                extract_note_text(html)
+            # 12th call should produce no warning (limit is 10)
+            assert "U+FFFD replacement characters" not in caplog.text
 
 
 class TestRoundtrip:

--- a/tests/unit/test_formatters.py
+++ b/tests/unit/test_formatters.py
@@ -1,5 +1,9 @@
 """Unit tests for formatting utilities in formatters.py module."""
 
+import logging
+
+import pytest
+
 from yazot.formatters import extract_note_text, format_note_html
 
 
@@ -100,6 +104,47 @@ class TestExtractNoteText:
     def test_nested_tags(self) -> None:
         result = extract_note_text("<div><div><p>Deep content</p></div></div>")
         assert "Deep content" in result
+
+
+class TestExtractNoteTextUnicode:
+    """Tests for Unicode handling in extract_note_text()."""
+
+    def test_cyrillic_text_preserved(self) -> None:
+        html = "<p>Перитонеальные рецепторы</p>"
+        result = extract_note_text(html)
+        assert "Перитонеальные рецепторы" in result
+
+    def test_replacement_char_removed(self) -> None:
+        html = "<p>перитон\ufffdальные</p>"
+        result = extract_note_text(html)
+        assert "\ufffd" not in result
+        assert "перитон" in result
+        assert "альные" in result
+
+    def test_replacement_char_logged(self, caplog: pytest.LogCaptureFixture) -> None:
+        html = "<p>перитон\ufffdальные</p>"
+        with caplog.at_level(logging.WARNING, logger="yazot.formatters"):
+            extract_note_text(html)
+        assert "U+FFFD" in caplog.text
+
+    def test_nfc_normalization(self) -> None:
+        # e + combining acute = decomposed form, should normalize to NFC
+        html = "<p>e\u0301</p>"
+        result = extract_note_text(html)
+        assert "\u00e9" in result  # NFC form
+
+    def test_mixed_scripts_preserved(self) -> None:
+        html = "<p>English and 中文 and العربية</p>"
+        result = extract_note_text(html)
+        assert "English" in result
+        assert "中文" in result
+        assert "العربية" in result
+
+    def test_clean_text_no_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        html = "<p>Clean text without issues</p>"
+        with caplog.at_level(logging.WARNING, logger="yazot.formatters"):
+            extract_note_text(html)
+        assert "U+FFFD" not in caplog.text
 
 
 class TestRoundtrip:

--- a/tests/unit/test_zotero_client.py
+++ b/tests/unit/test_zotero_client.py
@@ -1,0 +1,99 @@
+"""Tests for ZoteroClient.add_to_collection retry logic."""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pyzotero import zotero_errors
+
+from yazot.exceptions import ZoteroError
+from yazot.models import ZoteroItem
+
+
+def _make_item(key: str = "TESTKEY1", version: int = 100) -> ZoteroItem:
+    """Create a minimal ZoteroItem for testing."""
+    return ZoteroItem.model_validate(
+        {
+            "key": key,
+            "version": version,
+            "data": {
+                "key": key,
+                "version": version,
+                "itemType": "journalArticle",
+                "title": "Test Article",
+                "collections": [],
+            },
+            "meta": {},
+        }
+    )
+
+
+def _make_zotero_client() -> Any:
+    """Create a ZoteroClient with mocked internals for unit testing."""
+    with patch("yazot.zotero_client.ZoteroClient.__init__", return_value=None):
+        from yazot.zotero_client import ZoteroClient
+
+        zc = ZoteroClient.__new__(ZoteroClient)
+        zc._mode = "web"
+        zc._client = MagicMock()  # pyzotero client stub
+        zc._call = AsyncMock(return_value=None)
+        return zc
+
+
+class TestAddToCollectionRetry:
+    """Test 412 PreConditionFailed retry in add_to_collection."""
+
+    @pytest.mark.asyncio
+    async def test_success_no_retry(self) -> None:
+        """Normal add without version conflict — no retry needed."""
+        zc = _make_zotero_client()
+        item = _make_item()
+
+        await zc._add_item_to_collection("COLL1", item)
+
+        zc._call.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_retry_on_412(self) -> None:
+        """412 triggers re-fetch and single retry."""
+        zc = _make_zotero_client()
+        fresh_item = _make_item(version=200)
+
+        zc._call = AsyncMock(side_effect=[zotero_errors.PreConditionFailedError("412"), None])
+        zc.get_item = AsyncMock(return_value=fresh_item)
+
+        item = _make_item(version=100)
+        await zc._add_item_to_collection("COLL1", item)
+
+        assert zc._call.call_count == 2
+        zc.get_item.assert_called_once_with("TESTKEY1")
+
+    @pytest.mark.asyncio
+    async def test_412_after_retry_raises(self) -> None:
+        """Second 412 after retry raises ZoteroError."""
+        zc = _make_zotero_client()
+        fresh_item = _make_item(version=200)
+
+        zc._call = AsyncMock(
+            side_effect=[
+                zotero_errors.PreConditionFailedError("412"),
+                zotero_errors.PreConditionFailedError("412 again"),
+            ]
+        )
+        zc.get_item = AsyncMock(return_value=fresh_item)
+
+        item = _make_item(version=100)
+        with pytest.raises(ZoteroError, match="Version conflict.*after retry"):
+            await zc._add_item_to_collection("COLL1", item)
+
+    @pytest.mark.asyncio
+    async def test_non_412_error_not_retried(self) -> None:
+        """Non-412 PyZoteroError is not retried."""
+        zc = _make_zotero_client()
+        zc._call = AsyncMock(side_effect=zotero_errors.PyZoteroError("500 Server Error"))
+
+        item = _make_item()
+        with pytest.raises(ZoteroError, match="Failed to add item"):
+            await zc._add_item_to_collection("COLL1", item)
+
+        zc._call.assert_called_once()

--- a/yazot/formatters.py
+++ b/yazot/formatters.py
@@ -50,7 +50,7 @@ def parse_datetime(date_str: str) -> datetime:
 
 
 def format_dict_to_html(data: NoteData, level: int = 1) -> str:
-    """Convert dictionary to HTML with keys as headers.
+    """Convert dictionary to HTML with keys as headers (capitalized).
 
     Args:
         data: Dictionary to convert

--- a/yazot/formatters.py
+++ b/yazot/formatters.py
@@ -13,6 +13,8 @@ from bs4 import BeautifulSoup, Tag
 logger = logging.getLogger(__name__)
 
 REPLACEMENT_CHAR = "\ufffd"
+_replacement_char_notes_logged = 0
+_REPLACEMENT_LOG_LIMIT = 10
 
 type NoteData = dict[str, str | int | float | Sequence[str | int | float | NoteData] | NoteData]
 
@@ -28,10 +30,19 @@ def extract_note_text(html_content: str) -> str:
     result = result.strip()
     result = unicodedata.normalize("NFC", result)
     if REPLACEMENT_CHAR in result:
-        logger.warning(
-            "Note contains U+FFFD replacement characters — "
-            "likely encoding issue in Zotero API response"
-        )
+        global _replacement_char_notes_logged
+        _replacement_char_notes_logged += 1
+        if _replacement_char_notes_logged <= _REPLACEMENT_LOG_LIMIT:
+            logger.warning(
+                "Note contains %d U+FFFD replacement characters — "
+                "likely encoding issue in Zotero API response",
+                result.count(REPLACEMENT_CHAR),
+            )
+            if _replacement_char_notes_logged == _REPLACEMENT_LOG_LIMIT:
+                logger.warning(
+                    "Further U+FFFD warnings suppressed (limit %d reached)",
+                    _REPLACEMENT_LOG_LIMIT,
+                )
         result = result.replace(REPLACEMENT_CHAR, "")
     return result
 

--- a/yazot/formatters.py
+++ b/yazot/formatters.py
@@ -1,12 +1,18 @@
 """Formatting utilities for note content conversion."""
 
 import html
+import logging
+import unicodedata
 from collections.abc import Sequence
 from datetime import datetime
 
 import markdown as md
 import markdownify
 from bs4 import BeautifulSoup, Tag
+
+logger = logging.getLogger(__name__)
+
+REPLACEMENT_CHAR = "\ufffd"
 
 type NoteData = dict[str, str | int | float | Sequence[str | int | float | NoteData] | NoteData]
 
@@ -19,7 +25,15 @@ def format_note_html(text: str) -> str:
 def extract_note_text(html_content: str) -> str:
     """Convert HTML note back to readable markdown."""
     result: str = markdownify.markdownify(html_content, heading_style="ATX")
-    return result.strip()
+    result = result.strip()
+    result = unicodedata.normalize("NFC", result)
+    if REPLACEMENT_CHAR in result:
+        logger.warning(
+            "Note contains U+FFFD replacement characters — "
+            "likely encoding issue in Zotero API response"
+        )
+        result = result.replace(REPLACEMENT_CHAR, "")
+    return result
 
 
 def parse_datetime(date_str: str) -> datetime:

--- a/yazot/zotero_client.py
+++ b/yazot/zotero_client.py
@@ -753,30 +753,45 @@ class ZoteroClient(ZoteroClientProtocol):
     async def add_to_collection(self, collection_key: str, items: list[ZoteroItem]) -> None:
         """Add items to a collection."""
         for item in items:
-            try:
-                await self._call(
-                    self._client.addto_collection,
-                    collection_key,
-                    item.model_dump(by_alias=True),
-                )
-            except zotero_errors.ResourceNotFoundError as e:
-                raise ZoteroNotFoundError("collection", collection_key) from e
-            except zotero_errors.UserNotAuthorisedError as e:
+            await self._add_item_to_collection(collection_key, item)
+
+    async def _add_item_to_collection(
+        self, collection_key: str, item: ZoteroItem, *, retried: bool = False
+    ) -> None:
+        """Add a single item to a collection, retrying once on version conflict."""
+        try:
+            await self._call(
+                self._client.addto_collection,
+                collection_key,
+                item.model_dump(by_alias=True),
+            )
+        except zotero_errors.PreConditionFailedError as e:
+            if retried:
                 raise ZoteroError(
-                    f"Not authorized to modify collection '{collection_key}'. "
-                    "Hint: check that ZOTERO_API_KEY has write permissions."
+                    f"Version conflict for item '{item.key}' in collection '{collection_key}' "
+                    "after retry. Hint: the item is being modified by another client."
                 ) from e
-            except zotero_errors.PyZoteroError as e:
-                raise ZoteroError(
-                    f"Failed to add item '{item.key}' to collection '{collection_key}': {e}. "
-                    "Hint: verify the collection key exists and credentials are correct."
-                ) from e
-            except Exception as e:
-                raise ZoteroError(
-                    f"Unexpected error adding item '{item.key}' to collection "
-                    f"'{collection_key}': {type(e).__name__}: {e}. "
-                    "Hint: check network connectivity and web API credentials."
-                ) from e
+            logger.debug("Version conflict for item '%s', re-fetching and retrying", item.key)
+            fresh_item = await self.get_item(item.key)
+            await self._add_item_to_collection(collection_key, fresh_item, retried=True)
+        except zotero_errors.ResourceNotFoundError as e:
+            raise ZoteroNotFoundError("collection", collection_key) from e
+        except zotero_errors.UserNotAuthorisedError as e:
+            raise ZoteroError(
+                f"Not authorized to modify collection '{collection_key}'. "
+                "Hint: check that ZOTERO_API_KEY has write permissions."
+            ) from e
+        except zotero_errors.PyZoteroError as e:
+            raise ZoteroError(
+                f"Failed to add item '{item.key}' to collection '{collection_key}': {e}. "
+                "Hint: verify the collection key exists and credentials are correct."
+            ) from e
+        except Exception as e:
+            raise ZoteroError(
+                f"Unexpected error adding item '{item.key}' to collection "
+                f"'{collection_key}': {type(e).__name__}: {e}. "
+                "Hint: check network connectivity and web API credentials."
+            ) from e
 
     @webonly
     async def attach_pdf(self, item_key: str, filepath: str) -> None:


### PR DESCRIPTION
## Summary

- Notes from Zotero API may arrive with U+FFFD (replacement character) due to encoding issues at HTTP transport layer — apply NFC normalization and strip replacement chars in `extract_note_text()`, logging a warning for diagnostics
- Add 6 Unicode-specific tests (Cyrillic, CJK, Arabic, NFC normalization, replacement char handling)

## Summary by Sourcery

Normalize and sanitize extracted note text to handle Unicode replacement characters and improve robustness of note formatting.

Bug Fixes:
- Strip U+FFFD replacement characters from extracted note text and log a warning when they are encountered to help diagnose upstream encoding issues.

Enhancements:
- Apply NFC Unicode normalization to extracted note text to ensure consistent representation of accented and composed characters.

Tests:
- Add Unicode-focused tests covering Cyrillic, mixed-script content, NFC normalization, replacement character removal, and associated logging behavior.