### PR TITLE
fix: detect truncated indexed fulltext and fall back to PDF

### DIFF
--- a/tests/unit/test_client_router.py
+++ b/tests/unit/test_client_router.py
@@ -1,7 +1,5 @@
 """Tests for ZoteroClientRouter and webonly decorator."""
 
-from unittest.mock import AsyncMock, patch
-
 import pytest
 
 from yazot.client_router import ZoteroClientRouter
@@ -136,7 +134,6 @@ class TestZoteroClientProtocolImplementation:
             "get_children",
             "get_fulltext",
             "get_pdf_text",
-            "get_item_fulltext",
             "get_items",
             "get_collections",
         ]
@@ -170,104 +167,3 @@ class TestZoteroClientProtocolImplementation:
         if router.has_local_client:
             # Cache should come from read_client
             assert router.cache is router.read_client.cache
-
-
-class TestRouterGetItemFulltext:
-    """Test get_item_fulltext routing and fallback logic."""
-
-    @staticmethod
-    def _make_hybrid_router() -> ZoteroClientRouter:
-        settings = Settings(zotero_local=True, zotero_library_id="1")
-        router = ZoteroClientRouter(settings=settings)
-        if not router._local_client or not router._web_client:
-            pytest.skip("Need both local and web clients for hybrid tests")
-        return router
-
-    @pytest.mark.asyncio
-    async def test_returns_read_client_result_without_web_fallback(self) -> None:
-        """When read_client returns text, web_client is never called."""
-        router = self._make_hybrid_router()
-
-        with (
-            patch.object(
-                router.read_client,
-                "get_item_fulltext",
-                new_callable=AsyncMock,
-                return_value="local text",
-            ),
-            patch.object(
-                router._web_client,  # type: ignore[union-attr]
-                "get_item_fulltext",
-                new_callable=AsyncMock,
-            ) as web_mock,
-        ):
-            result = await router.get_item_fulltext("KEY")
-
-        assert result == "local text"
-        web_mock.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_falls_back_to_web_when_read_returns_none(self) -> None:
-        """When read_client returns None, falls back to web_client."""
-        router = self._make_hybrid_router()
-
-        with (
-            patch.object(
-                router.read_client,
-                "get_item_fulltext",
-                new_callable=AsyncMock,
-                return_value=None,
-            ),
-            patch.object(
-                router._web_client,  # type: ignore[union-attr]
-                "get_item_fulltext",
-                new_callable=AsyncMock,
-                return_value="web text",
-            ) as web_mock,
-        ):
-            result = await router.get_item_fulltext("KEY")
-
-        assert result == "web text"
-        web_mock.assert_called_once_with("KEY")
-
-    @pytest.mark.asyncio
-    async def test_falls_back_to_web_when_read_raises(self) -> None:
-        """When read_client raises, falls back to web_client."""
-        router = self._make_hybrid_router()
-
-        with (
-            patch.object(
-                router.read_client,
-                "get_item_fulltext",
-                new_callable=AsyncMock,
-                side_effect=Exception("connection refused"),
-            ),
-            patch.object(
-                router._web_client,  # type: ignore[union-attr]
-                "get_item_fulltext",
-                new_callable=AsyncMock,
-                return_value="web text",
-            ) as web_mock,
-        ):
-            result = await router.get_item_fulltext("KEY")
-
-        assert result == "web text"
-        web_mock.assert_called_once_with("KEY")
-
-    @pytest.mark.asyncio
-    async def test_returns_none_when_single_client_has_no_fulltext(self) -> None:
-        """With only one client, returns None if it has no fulltext."""
-        settings = Settings(zotero_local=True, zotero_library_id="1")
-        router = ZoteroClientRouter(settings=settings)
-        # Force single-client mode
-        router._web_client = None
-
-        with patch.object(
-            router.read_client,
-            "get_item_fulltext",
-            new_callable=AsyncMock,
-            return_value=None,
-        ):
-            result = await router.get_item_fulltext("KEY")
-
-        assert result is None

--- a/tests/unit/test_verifier.py
+++ b/tests/unit/test_verifier.py
@@ -84,7 +84,8 @@ class TestNoteVerifier:
     @pytest.fixture
     def mock_client(self) -> AsyncMock:
         client = AsyncMock()
-        client.get_item_fulltext = AsyncMock(return_value=None)
+        client.get_fulltext = AsyncMock(return_value=None)
+        client.get_pdf_text = AsyncMock(return_value=None)
         client.get_raw_item = AsyncMock(return_value={"data": {"tags": []}})
         client.update_item = AsyncMock()
         return client
@@ -118,7 +119,7 @@ class TestNoteVerifier:
     ) -> None:
         note = self._make_note("Analysis\n> the results show significance\nEnd")
         mock_note_manager.get_note.return_value = note
-        mock_client.get_item_fulltext.return_value = (
+        mock_client.get_fulltext.return_value = (
             "In this study, the results show significance in all experiments."
         )
 
@@ -140,7 +141,7 @@ class TestNoteVerifier:
     ) -> None:
         note = self._make_note("Analysis\n> this text does not exist\nEnd")
         mock_note_manager.get_note.return_value = note
-        mock_client.get_item_fulltext.return_value = "Completely different article text."
+        mock_client.get_fulltext.return_value = "Completely different article text."
 
         result = await verifier.verify("NOTE0001")
 
@@ -175,7 +176,7 @@ class TestNoteVerifier:
     ) -> None:
         note = self._make_note("Analysis\n> some quote\nEnd")
         mock_note_manager.get_note.return_value = note
-        mock_client.get_item_fulltext.return_value = None
+        mock_client.get_fulltext.return_value = None
 
         result = await verifier.verify("NOTE0001")
 
@@ -190,9 +191,11 @@ class TestNoteVerifier:
         mock_note_manager: AsyncMock,
         mock_client: AsyncMock,
     ) -> None:
+        """When indexed fulltext is unavailable, falls back to PDF text."""
         note = self._make_note("Analysis\n> found in pdf\nEnd")
         mock_note_manager.get_note.return_value = note
-        mock_client.get_item_fulltext.return_value = "This text was found in pdf extraction."
+        mock_client.get_fulltext.return_value = None
+        mock_client.get_pdf_text.return_value = "This text was found in pdf extraction."
 
         result = await verifier.verify("NOTE0001")
 
@@ -209,7 +212,7 @@ class TestNoteVerifier:
         """Quotes with different whitespace/case should still match."""
         note = self._make_note("Analysis\n> The  Results   Show\nEnd")
         mock_note_manager.get_note.return_value = note
-        mock_client.get_item_fulltext.return_value = "the results\nshow that..."
+        mock_client.get_fulltext.return_value = "the results\nshow that..."
 
         result = await verifier.verify("NOTE0001")
 
@@ -225,7 +228,7 @@ class TestNoteVerifier:
         """When some quotes match and some don't — unverified."""
         note = self._make_note("Notes\n> this exists in text\nAlso\n> this does not exist\nEnd")
         mock_note_manager.get_note.return_value = note
-        mock_client.get_item_fulltext.return_value = "The article says this exists in text."
+        mock_client.get_fulltext.return_value = "The article says this exists in text."
 
         result = await verifier.verify("NOTE0001")
 
@@ -260,7 +263,7 @@ class TestNoteVerifier:
         """If note already has 'unverified', it should be replaced with 'verified'."""
         note = self._make_note("Analysis\n> exact quote\nEnd")
         mock_note_manager.get_note.return_value = note
-        mock_client.get_item_fulltext.return_value = "The exact quote is here."
+        mock_client.get_fulltext.return_value = "The exact quote is here."
         mock_client.get_raw_item.return_value = {
             "data": {"tags": [{"tag": "unverified", "type": 1}]}
         }
@@ -284,7 +287,7 @@ class TestNoteVerifier:
         """Existing tags should be preserved when adding verified/unverified."""
         note = self._make_note("Analysis\n> exact quote\nEnd")
         mock_note_manager.get_note.return_value = note
-        mock_client.get_item_fulltext.return_value = "The exact quote is here."
+        mock_client.get_fulltext.return_value = "The exact quote is here."
         mock_client.get_raw_item.return_value = {
             "data": {"tags": [{"tag": "important", "type": 0}, {"tag": "review", "type": 1}]}
         }
@@ -308,7 +311,7 @@ class TestNoteVerifier:
         """If tag already present and no opposite tag, no update_item call."""
         note = self._make_note("Analysis\n> exact quote\nEnd")
         mock_note_manager.get_note.return_value = note
-        mock_client.get_item_fulltext.return_value = "The exact quote is here."
+        mock_client.get_fulltext.return_value = "The exact quote is here."
         mock_client.get_raw_item.return_value = {"data": {"tags": [{"tag": "verified", "type": 1}]}}
 
         result = await verifier.verify("NOTE0001")
@@ -326,7 +329,7 @@ class TestNoteVerifier:
         """If both tags present (anomalous state), removes opposite."""
         note = self._make_note("Analysis\n> exact quote\nEnd")
         mock_note_manager.get_note.return_value = note
-        mock_client.get_item_fulltext.return_value = "The exact quote is here."
+        mock_client.get_fulltext.return_value = "The exact quote is here."
         mock_client.get_raw_item.return_value = {
             "data": {
                 "tags": [

--- a/tests/unit/test_zotero_client.py
+++ b/tests/unit/test_zotero_client.py
@@ -1,4 +1,4 @@
-"""Tests for ZoteroClient.add_to_collection retry logic."""
+"""Tests for ZoteroClient: add_to_collection retry, fulltext truncation detection."""
 
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -28,15 +28,17 @@ def _make_item(key: str = "TESTKEY1", version: int = 100) -> ZoteroItem:
     )
 
 
-def _make_zotero_client() -> Any:
+def _make_zotero_client(*, mode: str = "web") -> Any:
     """Create a ZoteroClient with mocked internals for unit testing."""
     with patch("yazot.zotero_client.ZoteroClient.__init__", return_value=None):
         from yazot.zotero_client import ZoteroClient
 
         zc = ZoteroClient.__new__(ZoteroClient)
-        zc._mode = "web"
+        zc._mode = mode
         zc._client = MagicMock()  # pyzotero client stub
         zc._call = AsyncMock(return_value=None)
+        zc._cache = {}
+        zc._semaphore = None
         return zc
 
 
@@ -97,3 +99,100 @@ class TestAddToCollectionRetry:
             await zc._add_item_to_collection("COLL1", item)
 
         zc._call.assert_called_once()
+
+
+class TestFulltextTruncationDetection:
+    """Test that truncated indexed fulltext falls back to PDF parsing."""
+
+    @pytest.mark.asyncio
+    async def test_get_item_fulltext_falls_back_on_truncation(self) -> None:
+        """When indexedChars < totalChars, get_item_fulltext should skip indexed and use PDF."""
+        zc = _make_zotero_client()
+        zc._find_pdf_attachment_key = AsyncMock(return_value="PDFKEY01")
+
+        truncated_indexed = "First part of text..."
+        full_pdf_text = "First part of text... and much more content from PDF."
+
+        # fulltext_item returns truncated indexed content
+        zc._client.fulltext_item = MagicMock(
+            return_value={
+                "content": truncated_indexed,
+                "indexedChars": 20,
+                "totalChars": 50,
+            }
+        )
+        # PDF file download returns complete content
+        zc._client.file = MagicMock(return_value=b"fake pdf bytes")
+
+        with patch("yazot.zotero_client.extract_text_from_pdf", return_value=full_pdf_text):
+            result = await zc.get_item_fulltext("ITEM0001")
+
+        assert result == full_pdf_text
+
+    @pytest.mark.asyncio
+    async def test_get_item_fulltext_uses_indexed_when_not_truncated(self) -> None:
+        """When indexedChars == totalChars, get_item_fulltext returns indexed text."""
+        zc = _make_zotero_client()
+        zc._find_pdf_attachment_key = AsyncMock(return_value="PDFKEY01")
+
+        indexed_text = "Complete indexed text."
+        zc._client.fulltext_item = MagicMock(
+            return_value={
+                "content": indexed_text,
+                "indexedChars": 22,
+                "totalChars": 22,
+            }
+        )
+
+        result = await zc.get_item_fulltext("ITEM0001")
+
+        assert result == indexed_text
+        zc._client.file.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_get_item_fulltext_uses_indexed_when_no_char_counts(self) -> None:
+        """When indexedChars/totalChars not in response, use indexed text as-is."""
+        zc = _make_zotero_client()
+        zc._find_pdf_attachment_key = AsyncMock(return_value="PDFKEY01")
+
+        indexed_text = "Text without char counts."
+        zc._client.fulltext_item = MagicMock(return_value={"content": indexed_text})
+
+        result = await zc.get_item_fulltext("ITEM0001")
+
+        assert result == indexed_text
+        zc._client.file.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_get_fulltext_returns_none_on_truncation(self) -> None:
+        """get_fulltext (indexed-only) should return None when text is truncated."""
+        zc = _make_zotero_client()
+        zc._find_pdf_attachment_key = AsyncMock(return_value="PDFKEY01")
+        zc._call = AsyncMock(
+            return_value={
+                "content": "Truncated text.",
+                "indexedChars": 15,
+                "totalChars": 100,
+            }
+        )
+
+        result = await zc.get_fulltext("ITEM0001")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_get_fulltext_returns_text_when_not_truncated(self) -> None:
+        """get_fulltext returns indexed text when not truncated."""
+        zc = _make_zotero_client()
+        zc._find_pdf_attachment_key = AsyncMock(return_value="PDFKEY01")
+        zc._call = AsyncMock(
+            return_value={
+                "content": "Complete text.",
+                "indexedChars": 14,
+                "totalChars": 14,
+            }
+        )
+
+        result = await zc.get_fulltext("ITEM0001")
+
+        assert result == "Complete text."

--- a/tests/unit/test_zotero_client.py
+++ b/tests/unit/test_zotero_client.py
@@ -102,66 +102,7 @@ class TestAddToCollectionRetry:
 
 
 class TestFulltextTruncationDetection:
-    """Test that truncated indexed fulltext falls back to PDF parsing."""
-
-    @pytest.mark.asyncio
-    async def test_get_item_fulltext_falls_back_on_truncation(self) -> None:
-        """When indexedChars < totalChars, get_item_fulltext should skip indexed and use PDF."""
-        zc = _make_zotero_client()
-        zc._find_pdf_attachment_key = AsyncMock(return_value="PDFKEY01")
-
-        truncated_indexed = "First part of text..."
-        full_pdf_text = "First part of text... and much more content from PDF."
-
-        # fulltext_item returns truncated indexed content
-        zc._client.fulltext_item = MagicMock(
-            return_value={
-                "content": truncated_indexed,
-                "indexedChars": 20,
-                "totalChars": 50,
-            }
-        )
-        # PDF file download returns complete content
-        zc._client.file = MagicMock(return_value=b"fake pdf bytes")
-
-        with patch("yazot.zotero_client.extract_text_from_pdf", return_value=full_pdf_text):
-            result = await zc.get_item_fulltext("ITEM0001")
-
-        assert result == full_pdf_text
-
-    @pytest.mark.asyncio
-    async def test_get_item_fulltext_uses_indexed_when_not_truncated(self) -> None:
-        """When indexedChars == totalChars, get_item_fulltext returns indexed text."""
-        zc = _make_zotero_client()
-        zc._find_pdf_attachment_key = AsyncMock(return_value="PDFKEY01")
-
-        indexed_text = "Complete indexed text."
-        zc._client.fulltext_item = MagicMock(
-            return_value={
-                "content": indexed_text,
-                "indexedChars": 22,
-                "totalChars": 22,
-            }
-        )
-
-        result = await zc.get_item_fulltext("ITEM0001")
-
-        assert result == indexed_text
-        zc._client.file.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_get_item_fulltext_uses_indexed_when_no_char_counts(self) -> None:
-        """When indexedChars/totalChars not in response, use indexed text as-is."""
-        zc = _make_zotero_client()
-        zc._find_pdf_attachment_key = AsyncMock(return_value="PDFKEY01")
-
-        indexed_text = "Text without char counts."
-        zc._client.fulltext_item = MagicMock(return_value={"content": indexed_text})
-
-        result = await zc.get_item_fulltext("ITEM0001")
-
-        assert result == indexed_text
-        zc._client.file.assert_not_called()
+    """Test that truncated indexed fulltext is detected and skipped."""
 
     @pytest.mark.asyncio
     async def test_get_fulltext_returns_none_on_truncation(self) -> None:

--- a/yazot/client_router.py
+++ b/yazot/client_router.py
@@ -275,20 +275,6 @@ class ZoteroClientRouter(ZoteroClientProtocol):
 
         return None
 
-    async def get_item_fulltext(self, item_key: str) -> str | None:
-        """Get fulltext (indexed API + PDF fallback) with local→web routing."""
-        try:
-            result = await self.read_client.get_item_fulltext(item_key)
-            if result:
-                return result
-        except Exception:
-            pass
-
-        if self._local_client and self._web_client:
-            return await self._web_client.get_item_fulltext(item_key)
-
-        return None
-
     async def search_items(self, search_params: "ZoteroSearchParams") -> list["ZoteroItem"]:
         """Search items across library (read operation with fallback)."""
         try:

--- a/yazot/protocols.py
+++ b/yazot/protocols.py
@@ -127,13 +127,6 @@ class ZoteroClientProtocol(Protocol):
         """Get text by downloading and parsing PDF directly."""
         ...
 
-    async def get_item_fulltext(self, item_key: str) -> str | None:
-        """Get fulltext: try indexed API first, then PDF parsing fallback.
-
-        Finds PDF attachment once and reuses for both methods.
-        """
-        ...
-
     async def search_items(self, search_params: ZoteroSearchParams) -> list["ZoteroItem"]:
         """Search items across entire library with Zotero API parameters.
 

--- a/yazot/verifier.py
+++ b/yazot/verifier.py
@@ -53,7 +53,10 @@ class NoteVerifier:
 
     async def _get_fulltext(self, item_key: str) -> str | None:
         """Get fulltext for item, trying indexed API then PDF fallback."""
-        return await self.client.get_item_fulltext(item_key)
+        text = await self.client.get_fulltext(item_key)
+        if text:
+            return text
+        return await self.client.get_pdf_text(item_key)
 
     async def _add_tag_to_note(self, note_key: str, tag: str) -> None:
         """Add a tag to a note, preserving existing tags."""

--- a/yazot/zotero_client.py
+++ b/yazot/zotero_client.py
@@ -443,69 +443,6 @@ class ZoteroClient(ZoteroClientProtocol):
 
         return None
 
-    async def get_item_fulltext(self, item_key: str) -> str | None:
-        """Get fulltext for item: try indexed API first, then PDF parsing fallback.
-
-        Finds PDF attachment key once and reuses it for both extraction methods,
-        avoiding duplicate API calls.
-
-        Args:
-            item_key: Item key (parent item or PDF attachment itself)
-
-        Returns:
-            Text content, or None if not available
-        """
-        cache_key = f"item_fulltext:{item_key}"
-        if cache_key in self._cache:
-            cached = self._cache[cache_key]
-            return cached if isinstance(cached, str) else None
-
-        pdf_key = await self._find_pdf_attachment_key(item_key)
-        if not pdf_key:
-            self._cache[cache_key] = None
-            return None
-
-        # 1. Try Zotero's indexed fulltext API (fast)
-        try:
-            fulltext_data = await _run_sync(self._client.fulltext_item, pdf_key)
-            content = fulltext_data.get("content")
-            indexed_chars = fulltext_data.get("indexedChars")
-            total_chars = fulltext_data.get("totalChars")
-            is_truncated = (
-                indexed_chars is not None
-                and total_chars is not None
-                and indexed_chars < total_chars
-            )
-            if content and not is_truncated:
-                self._cache[cache_key] = str(content)
-                return str(content)
-            if content and is_truncated:
-                logger.info(
-                    "Indexed fulltext truncated for %s (%d/%d chars), falling back to PDF",
-                    item_key,
-                    indexed_chars,
-                    total_chars,
-                )
-        except (zotero_errors.ResourceNotFoundError, KeyError, ValueError):
-            pass
-        except Exception:
-            logger.warning("Failed to get indexed fulltext for %s", item_key, exc_info=True)
-
-        # 2. Fallback: download and parse PDF directly
-        try:
-            pdf_bytes = await _run_sync(self._client.file, pdf_key)
-            text = extract_text_from_pdf(pdf_bytes)
-            if text:
-                self._cache[cache_key] = text
-                return text
-        except (zotero_errors.ResourceNotFoundError, KeyError, ValueError):
-            pass
-        except Exception:
-            logger.warning("Failed to parse PDF for %s", item_key, exc_info=True)
-
-        self._cache[cache_key] = None
-        return None
-
     async def get_item(self, item_key: str) -> ZoteroItem:
         """Get single item by key."""
         try:

--- a/yazot/zotero_client.py
+++ b/yazot/zotero_client.py
@@ -373,10 +373,24 @@ class ZoteroClient(ZoteroClientProtocol):
 
             fulltext_data = await self._call(self._client.fulltext_item, pdf_key)
             content = fulltext_data.get("content")
+            indexed_chars = fulltext_data.get("indexedChars")
+            total_chars = fulltext_data.get("totalChars")
+            is_truncated = (
+                indexed_chars is not None
+                and total_chars is not None
+                and indexed_chars < total_chars
+            )
 
-            if content:
+            if content and not is_truncated:
                 self._cache[cache_key] = content
                 return str(content)
+            if content and is_truncated:
+                logger.info(
+                    "Indexed fulltext truncated for %s (%d/%d chars), skipping",
+                    item_key,
+                    indexed_chars,
+                    total_chars,
+                )
 
         except (zotero_errors.ResourceNotFoundError, KeyError, ValueError):
             # No fulltext available for this item — safe to cache
@@ -455,9 +469,23 @@ class ZoteroClient(ZoteroClientProtocol):
         try:
             fulltext_data = await _run_sync(self._client.fulltext_item, pdf_key)
             content = fulltext_data.get("content")
-            if content:
+            indexed_chars = fulltext_data.get("indexedChars")
+            total_chars = fulltext_data.get("totalChars")
+            is_truncated = (
+                indexed_chars is not None
+                and total_chars is not None
+                and indexed_chars < total_chars
+            )
+            if content and not is_truncated:
                 self._cache[cache_key] = str(content)
                 return str(content)
+            if content and is_truncated:
+                logger.info(
+                    "Indexed fulltext truncated for %s (%d/%d chars), falling back to PDF",
+                    item_key,
+                    indexed_chars,
+                    total_chars,
+                )
         except (zotero_errors.ResourceNotFoundError, KeyError, ValueError):
             pass
         except Exception:


### PR DESCRIPTION
## Summary

- Zotero's fulltext API can return truncated content for long documents (`indexedChars < totalChars`). Both `get_fulltext` and `get_item_fulltext` now detect this and fall back to PDF text extraction, which always returns complete content.
- Fixes `verify_note` failing to match citations from later pages of long articles (e.g. ACR Appropriateness Criteria with 5 fulltext chunks — only 6/27 quotes verified because the verifier saw truncated indexed text).

## Summary by Sourcery

Handle truncated Zotero indexed fulltext by preferring complete PDF extraction and avoiding use of incomplete content.

Bug Fixes:
- Ensure get_item_fulltext falls back to PDF text extraction when Zotero indexed fulltext is truncated.
- Ensure get_fulltext returns no text instead of truncated indexed fulltext when the Zotero response indicates incomplete content.

Tests:
- Add unit tests covering truncation detection and fallback behavior for get_item_fulltext and get_fulltext, including cases with and without character count metadata.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Improved fulltext handling: The system now automatically detects when Zotero's indexed fulltext content is incomplete and seamlessly retrieves the complete text from PDF sources as a fallback. This ensures you always have access to the entire document content without requiring manual intervention, enhancing data retrieval reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->