### PR TITLE
fix: remove empty-string content artifacts from fulltext error responses

### DIFF
--- a/tests/unit/test_external_fulltext.py
+++ b/tests/unit/test_external_fulltext.py
@@ -202,7 +202,7 @@ class TestFetchExternalFulltext:
                 )
                 response = result.data
 
-        assert response.content == ""
+        assert response.content is None
         assert response.error is not None
         assert "no text" in response.error.lower()
 

--- a/yazot/mcp_server.py
+++ b/yazot/mcp_server.py
@@ -577,7 +577,6 @@ async def get_item_fulltext(item_key: str, ctx: Context) -> FulltextResponse:
     if not fulltext:
         return FulltextResponse(
             item_key=item_key,
-            content="",
             error="No fulltext available for this item",
         ).to_slim_dict()  # type: ignore[return-value]
 
@@ -746,7 +745,6 @@ async def fetch_external_fulltext(
     if not text.strip():
         return ExternalFulltextResponse(
             item_key=item_key,
-            content="",
             source=source,
             error="PDF downloaded but no text could be extracted",
         ).to_slim_dict()  # type: ignore[return-value]

--- a/yazot/models.py
+++ b/yazot/models.py
@@ -255,7 +255,7 @@ class FulltextResponse(ChunkInfoMixin):
     """Response for fulltext content with chunking support."""
 
     item_key: str
-    content: str
+    content: str | None = None
     message: str | None = None
     error: str | None = None
 
@@ -264,7 +264,7 @@ class ExternalFulltextResponse(ChunkInfoMixin):
     """Response for externally fetched fulltext content."""
 
     item_key: str | None = None
-    content: str
+    content: str | None = None
     source: str | None = None
     pdf_attached: bool = False
     message: str | None = None


### PR DESCRIPTION
## Summary

- `FulltextResponse` and `ExternalFulltextResponse` used `content=""` in error cases — `to_slim_dict(exclude_none=True)` didn't filter empty strings, leaking phantom `content` fields into responses
- Changed `content: str` → `content: str | None = None` so error responses omit the field entirely

## Summary by Sourcery

Ensure fulltext error responses no longer include empty-string content fields by making content optional and updating callers accordingly.

Bug Fixes:
- Prevent phantom empty content fields from appearing in fulltext and external fulltext error responses.

Tests:
- Adjust external fulltext error handling test expectations to assert that content is omitted (None) when no text is extracted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated fulltext response structure to use optional content fields; responses without extracted text now return `None` instead of empty strings while preserving error information.

* **Tests**
  * Updated test assertions to reflect response structure changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->