### PR TITLE
docs: add rules for external package inspection and analyze recommendations

### DIFF
--- a/.claude/rules/analyze-recommendations.md
+++ b/.claude/rules/analyze-recommendations.md
@@ -1,0 +1,11 @@
+---
+description: Guidelines for /analyze skill recommendations
+---
+
+# Analyze recommendations
+
+When ranking solutions in `/analyze` reports:
+
+- Prefer **root-cause fixes** over defensive workarounds
+- "Single point of change" is a pro, but "masks the bug instead of fixing it" is a stronger con
+- A fix that changes 3 files but eliminates the bug is better than a 1-file fix that hides it in serialization

--- a/.claude/rules/inspect-external-packages.md
+++ b/.claude/rules/inspect-external-packages.md
@@ -1,0 +1,29 @@
+---
+globs: "yazot/**/*.py,tests/**/*.py"
+description: How to inspect external package APIs (FastMCP, pyzotero, etc.)
+---
+
+# Inspecting external package APIs
+
+## Do NOT grep site-packages
+
+`Grep` on `.venv/lib/.../site-packages/` fails silently on `.pyc`-only modules and misses code in mixin files. Don't waste tool calls on it.
+
+## Use `inspect.getsource()` instead
+
+```bash
+uv run python -c "
+import inspect
+from fastmcp import Client
+print(inspect.getsource(Client.call_tool))
+"
+```
+
+Always use `uv run python`, never bare `python` — the venv is not on PATH.
+
+## FastMCP Client.call_tool() → CallToolResult
+
+`Client.call_tool()` returns `CallToolResult(content, structured_content, meta, data, is_error)`.
+- `.data` — deserialized structured content (Pydantic model or dict), produced by `_parse_call_tool_result()` in `fastmcp.client.mixins.tools`
+- When a tool returns `to_slim_dict()` (a dict), FastMCP reconstructs the model via `output_schema` → `.data` is a typed dataclass with field access
+- Fields excluded by `exclude_none=True` in `model_dump()` become `None` on the reconstructed dataclass (not missing — just `None`)


### PR DESCRIPTION
## Summary

- `inspect-external-packages` rule: use `inspect.getsource()` instead of grepping site-packages, document FastMCP `CallToolResult.data` behavior
- `analyze-recommendations` rule: prefer root-cause fixes over defensive workarounds in `/analyze` reports
- Based on posthoc analysis of session 635966bc (PR #54 fulltext artifacts fix)

## Summary by Sourcery

Document internal guidelines for inspecting external package APIs and prioritizing root-cause fixes in /analyze reports.

Documentation:
- Add guidelines for inspecting external package APIs using inspect.getsource() instead of grepping site-packages, including FastMCP Client.call_tool() return semantics.
- Document recommendation heuristics for /analyze reports that prioritize root-cause fixes over defensive workarounds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidelines for evaluating and ranking solution recommendations, emphasizing root-cause fixes over workarounds.
  * Added guidance for inspecting external Python package APIs, including expected return shapes and structured output handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->