### PR TITLE
fix: treat empty blockquote lines as quote separators

### DIFF
--- a/tests/unit/test_verifier.py
+++ b/tests/unit/test_verifier.py
@@ -55,6 +55,15 @@ class TestExtractQuotes:
         text = "  > Indented quote"
         assert extract_quotes(text) == ["Indented quote"]
 
+    def test_adjacent_blockquotes_after_roundtrip(self) -> None:
+        """Empty > line (from HTML roundtrip) separates quotes."""
+        text = "Intro\n> Quote one\n>\n> Quote two\nEnd"
+        assert extract_quotes(text) == ["Quote one", "Quote two"]
+
+    def test_multiline_quotes_separated_by_empty_blockquote(self) -> None:
+        text = "> Line one\n> Line two\n>\n> Line three\n> Line four"
+        assert extract_quotes(text) == ["Line one Line two", "Line three Line four"]
+
 
 class TestNormalizeText:
     """Unit tests for text normalization."""

--- a/yazot/verifier.py
+++ b/yazot/verifier.py
@@ -23,7 +23,11 @@ def extract_quotes(text: str) -> list[str]:
         if stripped.startswith(">"):
             # Remove one or more '>' prefixes and optional space
             content = re.sub(r"^>+\s?", "", stripped)
-            current_quote_lines.append(content)
+            if content.strip():
+                current_quote_lines.append(content)
+            elif current_quote_lines:
+                quotes.append(" ".join(current_quote_lines))
+                current_quote_lines = []
         else:
             if current_quote_lines:
                 quotes.append(" ".join(current_quote_lines))


### PR DESCRIPTION
## Summary

- Markdown roundtrip merges adjacent `> A` / `> B` blocks into one `<blockquote>`, and markdownify recovers them with empty `>` lines — `extract_quotes()` was joining these into a single combined quote not found in fulltext, causing mass "unverified" tags
- Empty `>` lines now flush the current quote, treating them as separators between independent blockquotes

## Summary by Sourcery

Adjust quote extraction to treat empty blockquote lines as separators between distinct quotes.

Bug Fixes:
- Prevent adjacent blockquotes separated by empty `>` lines from being merged into a single quote during extraction.

Tests:
- Add unit tests covering adjacent blockquotes and multiline quotes separated by empty blockquote lines.