### PR TITLE
fix: normalize Unicode dashes and NFC form in verify_note

### DIFF
--- a/tests/unit/test_verifier.py
+++ b/tests/unit/test_verifier.py
@@ -77,6 +77,36 @@ class TestNormalizeText:
     def test_empty(self) -> None:
         assert normalize_text("") == ""
 
+    def test_en_dash_normalized(self) -> None:
+        assert normalize_text("blood\u2013pressure") == "blood-pressure"
+
+    def test_em_dash_normalized(self) -> None:
+        assert normalize_text("she said\u2014nothing") == "she said-nothing"
+
+    def test_unicode_hyphen_normalized(self) -> None:
+        assert normalize_text("co\u2010operation") == "co-operation"
+
+    def test_non_breaking_hyphen_normalized(self) -> None:
+        assert normalize_text("non\u2011breaking") == "non-breaking"
+
+    def test_horizontal_bar_normalized(self) -> None:
+        assert normalize_text("a\u2015b") == "a-b"
+
+    def test_minus_sign_normalized(self) -> None:
+        assert normalize_text("p\u2212value") == "p-value"
+
+    def test_ascii_hyphen_preserved(self) -> None:
+        assert normalize_text("blood-pressure") == "blood-pressure"
+
+    def test_nfc_precomposed_vs_decomposed(self) -> None:
+        decomposed = "caf\u0065\u0301"
+        precomposed = "caf\u00e9"
+        assert normalize_text(decomposed) == normalize_text(precomposed)
+
+    def test_idempotent(self) -> None:
+        text = "Blood\u2013pressure  Test"
+        assert normalize_text(normalize_text(text)) == normalize_text(text)
+
 
 class TestNoteVerifier:
     """Integration tests for NoteVerifier with mocked dependencies."""
@@ -217,6 +247,25 @@ class TestNoteVerifier:
         result = await verifier.verify("NOTE0001")
 
         assert result.verified is True
+
+    @pytest.mark.asyncio
+    async def test_unicode_dash_in_quote_matches_ascii_in_fulltext(
+        self,
+        verifier: NoteVerifier,
+        mock_note_manager: AsyncMock,
+        mock_client: AsyncMock,
+    ) -> None:
+        """Quote with en-dash from PDF copy matches ASCII hyphen in indexed text."""
+        note = self._make_note("Notes\n> blood\u2013pressure measurement\nEnd")
+        mock_note_manager.get_note.return_value = note
+        mock_client.get_fulltext.return_value = (
+            "We performed blood-pressure measurement on subjects."
+        )
+
+        result = await verifier.verify("NOTE0001")
+
+        assert result.verified is True
+        assert result.verified_quotes == 1
 
     @pytest.mark.asyncio
     async def test_partial_verification(

--- a/yazot/verifier.py
+++ b/yazot/verifier.py
@@ -1,6 +1,7 @@
 """Verification of quotes in notes against article fulltext."""
 
 import re
+import unicodedata
 from typing import TYPE_CHECKING
 
 from .models import ItemUpdate, VerificationResult, ZoteroTag
@@ -36,8 +37,13 @@ def extract_quotes(text: str) -> list[str]:
     return [q for q in quotes if q.strip()]
 
 
+_DASH_PATTERN = re.compile(r"[\u2010\u2011\u2013\u2014\u2015\u2212]")
+
+
 def normalize_text(text: str) -> str:
-    """Normalize text for comparison: lowercase, collapse whitespace."""
+    """Normalize text for comparison: NFC, dashes, whitespace, lowercase."""
+    text = unicodedata.normalize("NFC", text)
+    text = _DASH_PATTERN.sub("-", text)
     text = text.lower()
     text = re.sub(r"\s+", " ", text)
     text = text.strip()


### PR DESCRIPTION
- Subagents using `verify_note` regularly hit false negatives on quotes copied from PDFs because the indexed fulltext uses ASCII hyphens while PDFs emit en/em-dash, non-breaking hyphen, or minus sign. Decomposed Unicode forms (e.g., `e` + combining acute) caused the same failure.
- `normalize_text` now applies NFC canonical composition and maps U+2010/2011/2013/2014/2015/2212 to ASCII `-` before substring comparison, eliminating most retry loops without changing the exact-match semantics.

## Summary by Sourcery

Normalize note verification text to handle Unicode dashes and canonical composition for more robust quote matching.

Bug Fixes:
- Fix false-negative quote verification when notes contain various Unicode dash characters but indexed text uses ASCII hyphens.
- Fix quote verification mismatches caused by decomposed Unicode characters by normalizing text to NFC before comparison.

Tests:
- Add unit tests covering Unicode dash normalization, NFC normalization behavior, and idempotence of text normalization.
- Add integration test ensuring quotes with Unicode dashes match fulltext containing ASCII hyphens in note verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved quote-to-fulltext matching to consistently normalize various dash and punctuation characters, ensuring quotes with different hyphen formats correctly match their corresponding text.

* **Tests**
  * Added comprehensive test coverage for text normalization, including Unicode equivalence verification and matching consistency validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->