### PR TITLE
fix: decode HTML entities in verify_note normalization

### DIFF
--- a/tests/unit/test_verifier.py
+++ b/tests/unit/test_verifier.py
@@ -116,6 +116,27 @@ class TestNormalizeText:
         text = "Blood\u2013pressure  Test"
         assert normalize_text(normalize_text(text)) == normalize_text(text)
 
+    def test_html_entity_nbsp(self) -> None:
+        assert normalize_text("foo&nbsp;bar") == "foo bar"
+
+    def test_html_entity_quot(self) -> None:
+        assert normalize_text("she said &quot;hi&quot;") == 'she said "hi"'
+
+    def test_html_entity_amp(self) -> None:
+        assert normalize_text("Smith &amp; Jones") == "smith & jones"
+
+    def test_html_entity_lt_gt(self) -> None:
+        assert normalize_text("a&lt;b&gt;c") == "a<b>c"
+
+    def test_html_numeric_entity_decoded(self) -> None:
+        assert normalize_text("co&#8208;operation") == "co-operation"
+
+    def test_html_hex_entity_decoded(self) -> None:
+        assert normalize_text("blood&#x2013;pressure") == "blood-pressure"
+
+    def test_malformed_entity_preserved(self) -> None:
+        assert normalize_text("a &xyz; b") == "a &xyz; b"
+
 
 class TestNoteVerifier:
     """Integration tests for NoteVerifier with mocked dependencies."""
@@ -269,6 +290,25 @@ class TestNoteVerifier:
         mock_note_manager.get_note.return_value = note
         mock_client.get_fulltext.return_value = (
             "We performed blood-pressure measurement on subjects."
+        )
+
+        result = await verifier.verify("NOTE0001")
+
+        assert result.verified is True
+        assert result.verified_quotes == 1
+
+    @pytest.mark.asyncio
+    async def test_html_entity_in_quote_matches_decoded_fulltext(
+        self,
+        verifier: NoteVerifier,
+        mock_note_manager: AsyncMock,
+        mock_client: AsyncMock,
+    ) -> None:
+        """Quote with HTML entity from Zotero note matches decoded text in fulltext."""
+        note = self._make_note("Notes\n> Smith &amp; Jones reported a 30&nbsp;mg dose\nEnd")
+        mock_note_manager.get_note.return_value = note
+        mock_client.get_fulltext.return_value = (
+            "Smith & Jones reported a 30 mg dose in their study."
         )
 
         result = await verifier.verify("NOTE0001")

--- a/yazot/verifier.py
+++ b/yazot/verifier.py
@@ -1,5 +1,6 @@
 """Verification of quotes in notes against article fulltext."""
 
+import html
 import re
 import unicodedata
 from typing import TYPE_CHECKING
@@ -45,7 +46,8 @@ _DASH_PATTERN = re.compile(r"[\u2010\u2011\u2013\u2014\u2015\u2212]")
 
 
 def normalize_text(text: str) -> str:
-    """Normalize text for comparison: NFC, dashes, whitespace, lowercase."""
+    """Normalize text for comparison: HTML entities, NFC, dashes, whitespace, lowercase."""
+    text = html.unescape(text)
     text = unicodedata.normalize("NFC", text)
     text = _DASH_PATTERN.sub("-", text)
     text = text.lower()


### PR DESCRIPTION
- Zotero notes can contain HTML entities (`&nbsp;`, `&amp;`, `&quot;`, numeric `&#NNN;`, hex `&#xNNNN;`) that did not match decoded characters in indexed fulltext, causing `verify_note` false negatives
- Apply `html.unescape()` inside `normalize_text` before NFC and dash normalization so entity-encoded quotes match plain-text fulltext
- Completes the three-part `verify_note` normalization fix together with #56 (blockquote separation) and #58 (Unicode dashes + NFC)

## Summary by Sourcery

Decode HTML entities during text normalization so note quotes and fulltext are compared on the same basis.

Bug Fixes:
- Ensure HTML entity-encoded characters in notes match decoded characters in indexed fulltext during verification.

Tests:
- Add unit and integration tests covering HTML entity decoding, including common named, numeric, hex, and malformed entities in note text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced quote verification to properly handle HTML entities in source text, improving match accuracy between encoded quotes and decoded fulltext.

* **Tests**
  * Added comprehensive test coverage for HTML entity decoding, including common entities and numeric/hex character references, plus malformed entity handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->